### PR TITLE
chore: decouple changeset versions — each package versions independently

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/changelog-git",
   "commit": false,
-  "linked": [["@wasmagent/agentbom-core", "@wasmagent/agentbom-autogen", "@wasmagent/agentbom-langchain", "@wasmagent/agentbom-llamaindex"]],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
Removes linked[] config so agentbom-core, agentbom-autogen, agentbom-langchain, agentbom-llamaindex each version based on their own changes only.