### PR TITLE
fix: use NODE_AUTH_TOKEN for npm publish in release workflow

### DIFF
--- a/.changeset/publish-retry-2.md
+++ b/.changeset/publish-retry-2.md
@@ -1,0 +1,5 @@
+---
+"@wasmagent/agentbom-core": patch
+---
+
+chore: fix release workflow npm authentication

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-          registry-url: https://registry.npmjs.org
+          registry-url: "https://registry.npmjs.org"
       - run: bun install --frozen-lockfile
       - run: bun run build
-      - name: Set npm registry
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: changesets/action@v1
         with:
           version: bun run release:version
@@ -38,5 +34,5 @@ jobs:
           title: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Fixes npm auth in release.yml: use actions/setup-node registry-url + NODE_AUTH_TOKEN (official pattern) instead of manually writing .npmrc. Resolves persistent E404 on publish.