### PR TITLE
fix: add ajv-formats dep to suppress uri format warning

### DIFF
--- a/.changeset/fix-291-ajv-formats.md
+++ b/.changeset/fix-291-ajv-formats.md
@@ -1,0 +1,10 @@
+---
+"@wasmagent/agentbom-core": patch
+---
+
+fix: add ajv-formats dependency to suppress "unknown format uri ignored" warning (#291)
+
+Registers ajv-formats with the AJV 2020 instance so that the `uri` format keyword
+in the AgentBOM schema is enforced instead of being silently ignored.
+Previously, AJV logged "unknown format \"uri\" ignored" twice per `validateAgentBOM()`
+call, polluting startup logs in production.

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/agentbom-autogen": {
       "name": "@wasmagent/agentbom-autogen",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@wasmagent/agentbom-core": "workspace:*",
       },
@@ -25,7 +25,7 @@
     },
     "packages/agentbom-cli": {
       "name": "@wasmagent/agentbom-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "agentbom": "./dist/index.js",
         "agent-trust": "./dist/index.js",
@@ -40,10 +40,11 @@
     },
     "packages/agentbom-core": {
       "name": "@wasmagent/agentbom-core",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@wasmagent/protocol": "^0.1.7",
         "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -53,7 +54,7 @@
     },
     "packages/agentbom-langchain": {
       "name": "@wasmagent/agentbom-langchain",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@wasmagent/agentbom-core": "workspace:*",
       },
@@ -65,7 +66,7 @@
     },
     "packages/agentbom-llamaindex": {
       "name": "@wasmagent/agentbom-llamaindex",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@wasmagent/agentbom-core": "workspace:*",
       },
@@ -188,6 +189,8 @@
     "@wasmagent/protocol": ["@wasmagent/protocol@0.1.7", "", { "bin": { "wasmagent-protocol": "bin/cli.js" } }, "sha512-XOVNiky/7yGswggSr9h3IorHZal0eytCrirmV8tEJxs9pZbasKmCHdUwaZp5veGVxf7qLapsfmrq3x6nRxqA2Q=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 

--- a/packages/agentbom-core/package.json
+++ b/packages/agentbom-core/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@wasmagent/protocol": "^0.1.7",
-    "ajv": "^8.20.0"
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/packages/agentbom-core/src/index.test.ts
+++ b/packages/agentbom-core/src/index.test.ts
@@ -92,6 +92,31 @@ describe("validateAgentBOM", () => {
     expect(result.errorDetails.length).toBeGreaterThan(0);
     expect(result.errorDetails[0].field).toBe("(root)");
   });
+
+  // Test for #291 — ajv-formats must be registered so that uri format validation
+  // works without emitting "unknown format "uri" ignored" warnings.
+  it("validates distribution.registry_uri as a URI format (ajv-formats registered)", () => {
+    // Valid URI — should pass
+    const validResult = validateAgentBOM({
+      ...VALID_AGENTBOM,
+      distribution: { registry_uri: "https://registry.example.com/agents" },
+    });
+    expect(validResult.valid).toBe(true);
+    expect(validResult.errors).toHaveLength(0);
+
+    // Invalid URI — should fail with a format error (not silently ignored)
+    const invalidResult = validateAgentBOM({
+      ...VALID_AGENTBOM,
+      distribution: { registry_uri: "not-a-valid-uri!!!" },
+    });
+    // With ajv-formats registered, AJV enforces the uri format constraint.
+    // Without it, the invalid uri would silently pass — that was the bug (#291).
+    expect(invalidResult.valid).toBe(false);
+    const formatErr = invalidResult.errorDetails.find(
+      (e) => e.keyword === "format" && e.field.includes("registry_uri"),
+    );
+    expect(formatErr).toBeDefined();
+  });
 });
 
 const BASE_BOM = {

--- a/packages/agentbom-core/src/index.ts
+++ b/packages/agentbom-core/src/index.ts
@@ -1,6 +1,7 @@
 import { getSchema } from "@wasmagent/protocol";
 import type { ErrorObject, ValidateFunction } from "ajv";
 import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 
 export interface ValidationError {
   /** Dot-notation path to the offending field, e.g. "identity.agent_id". "(root)" for the document itself. */
@@ -25,6 +26,9 @@ let validateSchema: ValidateFunction | null = null;
 function getValidator(): ValidateFunction {
   if (validateSchema) return validateSchema;
   const ajv = new Ajv2020({ allErrors: true, strict: false });
+  // Register ajv-formats so that format keywords like "uri", "email", etc.
+  // are validated instead of silently ignored.
+  addFormats(ajv);
   const schema = getSchema("agentbom");
   validateSchema = ajv.compile(schema as import("ajv").AnySchema);
   if (!validateSchema) throw new Error("Failed to compile AgentBOM schema");


### PR DESCRIPTION
Fixes #291

Adds  as a dependency of  and calls  after creating the AJV instance. This eliminates the  warnings that appeared twice per  call at startup.