### PR TITLE
docs: fix drift — agent-trust-infra archived, CLI now in-repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,6 @@ Ships a pure-function core (`@wasmagent/agentbom-core`) and thin framework adapt
 (LangChain, LlamaIndex, AutoGen) that wrap it.
 
 **Is NOT — do not implement these here:**
-- A CLI tool (CLI lives in `agent-trust-infra` during transition; long-term it gets a dedicated tool repo)
 - A runtime agent framework, MCP firewall, or AEP emitter (`wasmagent-js` territory)
 - A schema definition layer — all schemas come from `@wasmagent/protocol`
 - A compliance-report generator or audit dashboard (`open-agent-audit` territory)
@@ -21,14 +20,13 @@ Ships a pure-function core (`@wasmagent/agentbom-core`) and thin framework adapt
 - `@wasmagent/agentbom-langchain` — LangChain adapter (depends on core + LangChain peer dep)
 - `@wasmagent/agentbom-llamaindex` — LlamaIndex adapter (depends on core + LlamaIndex peer dep)
 - `@wasmagent/agentbom-autogen` — AutoGen adapter (depends on core + AutoGen peer dep)
+- `@wasmagent/agentbom-cli` — developer CLI (`packages/agentbom-cli`); depends on core + published `@wasmagent`/`@openagentaudit` packages
 
 ### Other repositories own — do not duplicate here
 
 | Capability | Owner |
 |---|---|
 | AgentBOM **schema** JSON (canonical SSOT) | `wasmagent-protocol` (`@wasmagent/protocol`) |
-| AgentBOM + MCP Posture **specifications** | `agent-trust-infra` |
-| CLI (`agentbom validate`, `agentbom inspect`) | `agent-trust-infra` (`cli/`) — transitional |
 | Compliance report generation, audit dashboard | `open-agent-audit` |
 | AEP emitter, MCP firewall, runtime protection | `wasmagent-js` |
 
@@ -63,7 +61,7 @@ packages/
 
 ## NO-DO list
 
-- **No CLI command handlers here** — argument parsing, `process.exit`, stderr output belong in the CLI package in `agent-trust-infra`
+- **No CLI command handlers in `agentbom-core` or the adapters** — argument parsing, `process.exit`, and stderr output belong in the `agentbom-cli` package
 - **No file I/O in library code** — `pipeline.ts` uses `node:fs` internally (that is its job); all other core exports must not touch the filesystem
 - **No schema duplication** — never define an AgentBOM schema in this repo; always import from `@wasmagent/protocol`
 - **No framework-specific code in `agentbom-core`** — LangChain / LlamaIndex / AutoGen types belong in their respective adapter packages
@@ -114,6 +112,6 @@ bun changeset publish  # publish to npm (CI only)
 
 ## Strategic context
 
-This repo was split out from `agent-trust-infra` to give the AgentBOM library a clean,
-framework-neutral home. The `agent-trust-infra` CLI still wraps these packages during the
-transition period. Schema authority stays in `wasmagent-protocol`.
+This repo was split out from `agent-trust-infra` (now archived) to give the AgentBOM
+library a clean, framework-neutral home. The CLI has since migrated here as
+`@wasmagent/agentbom-cli`. Schema authority stays in `wasmagent-protocol`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ console.log(formatDriftAlert(alert));
 | `agentbom-langchain` | `@wasmagent/agentbom-langchain` | LangChain adapter |
 | `agentbom-llamaindex` | `@wasmagent/agentbom-llamaindex` | LlamaIndex adapter |
 | `agentbom-autogen` | `@wasmagent/agentbom-autogen` | AutoGen adapter |
+| `agentbom-cli` | `@wasmagent/agentbom-cli` | Developer CLI — `agentbom validate`, `inspect`, compliance, trust-chain, drift |
 
 ## Standards alignment
 
@@ -81,15 +82,15 @@ is itself a verifiable external trust signal.
 | Repository | Role |
 |------------|------|
 | [`wasmagent-protocol`](https://github.com/WasmAgent/wasmagent-protocol) | Canonical AgentBOM JSON schema (SSOT) |
-| [`agent-trust-infra`](https://github.com/WasmAgent/agent-trust-infra) | AgentBOM + MCP Posture specifications and CLI (`agentbom validate`) |
+| [`agent-trust-infra`](https://github.com/WasmAgent/agent-trust-infra) | **Archived** — original home of these packages; superseded by this repo |
 | [`open-agent-audit`](https://github.com/WasmAgent/open-agent-audit) | Compliance report generation and audit dashboard |
 
 The schema that drives all validation in `agentbom-core` is defined in `wasmagent-protocol`
 and imported via `@wasmagent/protocol`. Never copy or redefine it here.
 
-The CLI (`agentbom validate`, `agentbom inspect`) is in `agent-trust-infra` for the transition
-period; it wraps the packages in this repo.
+The CLI (`agentbom validate`, `agentbom inspect`) now lives in this repo as
+`@wasmagent/agentbom-cli` (`packages/agentbom-cli`), wrapping the library packages here.
 
 ---
 
-*Migrated from [WasmAgent/agent-trust-infra](https://github.com/WasmAgent/agent-trust-infra) — the library packages have a new home here while the specifications and CLI remain in that repo during the transition.*
+*Migrated from [WasmAgent/agent-trust-infra](https://github.com/WasmAgent/agent-trust-infra) (now archived) — the library packages and the CLI have their permanent home here. Schema authority stays in [`wasmagent-protocol`](https://github.com/WasmAgent/wasmagent-protocol).*


### PR DESCRIPTION
The README and CLAUDE.md still described the CLI and specifications as living in `agent-trust-infra` during a transition period. That repo is now **archived** and superseded by this one, and the CLI has already migrated here as `@wasmagent/agentbom-cli` (`packages/agentbom-cli`).

Changes:
- README: mark `agent-trust-infra` as archived/superseded; state the CLI now lives here; add `agentbom-cli` to the Packages table; fix the migration footer.
- CLAUDE.md: remove stale "CLI lives in agent-trust-infra" boundary rows; add `agentbom-cli` to the owned-packages list; re-scope the no-CLI-handlers rule to core/adapters; update the strategic-context footer.

No behavioral change; docs only. Verified `bun run lint` clean.