### PR TITLE
refactor: extract duplicated code into shared modules; add agentbom validate command

### DIFF
--- a/packages/agentbom-autogen/src/index.ts
+++ b/packages/agentbom-autogen/src/index.ts
@@ -10,6 +10,10 @@
  * AutoGen) pass the relevant fields from their runtime agent instance.
  */
 
+import { type AgentBOMRecord, buildAgentBOM } from "@wasmagent/agentbom-core";
+
+export type { AgentBOMRecord } from "@wasmagent/agentbom-core";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -85,60 +89,6 @@ export interface AutoGenWorkflowConfig {
   steps: AutoGenWorkflowStep[];
 }
 
-/** The shape of a generated AgentBOM document. */
-export interface AgentBOMRecord {
-  agentbom_version: string;
-  identity: {
-    agent_id: string;
-    agent_name: string;
-    agent_version?: string;
-    deployment_context?: string;
-    generated_at: string;
-  };
-  model_layer?: {
-    provider: string;
-    model_id: string;
-    model_version?: string;
-    capabilities?: string[];
-  };
-  tool_layer?: Array<{
-    tool_id: string;
-    tool_name: string;
-    source: "mcp" | "builtin" | "plugin";
-    mcp_server_id?: string;
-    skills?: string[];
-    permissions?: string[];
-    risk_signals?: string[];
-  }>;
-  prompt_layer?: {
-    system_prompt_hash?: string;
-    prompt_version?: string;
-    template_ids?: string[];
-  };
-  permission_layer?: {
-    granted_scopes?: string[];
-    data_access?: string[];
-    credential_references?: string[];
-  };
-  workflow_layer?: Array<{
-    workflow_id: string;
-    workflow_name: string;
-    description?: string;
-    version?: string;
-    steps: Array<{
-      step_id: string;
-      action: string;
-      description?: string;
-      depends_on?: string[];
-      allowed_tools?: string[];
-    }>;
-  }>;
-  attestation: {
-    generator: string;
-    generator_version: string;
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Generator
 // ---------------------------------------------------------------------------
@@ -154,114 +104,8 @@ const GENERATOR_VERSION = "0.0.0-research";
  * against `specs/agentbom/schema.json`.
  */
 export function generateAgentBOM(config: AutoGenAgentConfig): AgentBOMRecord {
-  const now = new Date().toISOString();
-
-  const tool_layer = (config.tools ?? []).map((t) => ({
-    tool_id: t.id ?? slugify(t.name),
-    tool_name: t.description ?? t.name,
-    source: t.source ?? "builtin",
-    ...(t.mcp_server_id ? { mcp_server_id: t.mcp_server_id } : {}),
-    ...(t.skills?.length ? { skills: t.skills } : {}),
-    ...(t.permissions?.length ? { permissions: t.permissions } : {}),
-    ...(t.risk_signals?.length ? { risk_signals: t.risk_signals } : {}),
-  }));
-
-  const bom: AgentBOMRecord = {
-    agentbom_version: "0.1",
-    identity: {
-      agent_id: config.agent_id,
-      agent_name: config.agent_name,
-      ...(config.agent_version ? { agent_version: config.agent_version } : {}),
-      ...(config.deployment_context
-        ? { deployment_context: config.deployment_context }
-        : {}),
-      generated_at: now,
-    },
-    ...(config.llm
-      ? {
-          model_layer: {
-            provider: config.llm.provider,
-            model_id: config.llm.model_id,
-            ...(config.llm.model_version
-              ? { model_version: config.llm.model_version }
-              : {}),
-            ...(config.llm.capabilities?.length
-              ? { capabilities: config.llm.capabilities }
-              : {}),
-          },
-        }
-      : {}),
-    ...(tool_layer.length ? { tool_layer } : {}),
-    ...(config.system_prompt_hash ||
-    config.prompt_version ||
-    config.template_ids?.length
-      ? {
-          prompt_layer: {
-            ...(config.system_prompt_hash
-              ? { system_prompt_hash: config.system_prompt_hash }
-              : {}),
-            ...(config.prompt_version
-              ? { prompt_version: config.prompt_version }
-              : {}),
-            ...(config.template_ids?.length
-              ? { template_ids: config.template_ids }
-              : {}),
-          },
-        }
-      : {}),
-    ...(config.granted_scopes?.length ||
-    config.data_access?.length ||
-    config.credential_references?.length
-      ? {
-          permission_layer: {
-            ...(config.granted_scopes?.length
-              ? { granted_scopes: config.granted_scopes }
-              : {}),
-            ...(config.data_access?.length
-              ? { data_access: config.data_access }
-              : {}),
-            ...(config.credential_references?.length
-              ? { credential_references: config.credential_references }
-              : {}),
-          },
-        }
-      : {}),
-    ...(config.workflows?.length
-      ? {
-          workflow_layer: config.workflows.map((wf) => ({
-            workflow_id: wf.workflow_id,
-            workflow_name: wf.workflow_name,
-            ...(wf.description ? { description: wf.description } : {}),
-            ...(wf.version ? { version: wf.version } : {}),
-            steps: wf.steps.map((s) => ({
-              step_id: s.step_id,
-              action: s.action,
-              ...(s.description ? { description: s.description } : {}),
-              ...(s.depends_on?.length ? { depends_on: s.depends_on } : {}),
-              ...(s.allowed_tools?.length
-                ? { allowed_tools: s.allowed_tools }
-                : {}),
-            })),
-          })),
-        }
-      : {}),
-    attestation: {
-      generator: GENERATOR,
-      generator_version: GENERATOR_VERSION,
-    },
-  };
-
-  return bom;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Convert a human-readable name to a URL-friendly slug for use as `tool_id`. */
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+  return buildAgentBOM(config, {
+    generator: GENERATOR,
+    generator_version: GENERATOR_VERSION,
+  });
 }

--- a/packages/agentbom-cli/src/agentbom-diff.ts
+++ b/packages/agentbom-cli/src/agentbom-diff.ts
@@ -1,10 +1,10 @@
-import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   diffAgentBOM,
   formatAgentBOMDiff,
   validateAgentBOM,
 } from "@wasmagent/agentbom-core";
+import { readArtifactFile } from "./trust-publish.js";
 
 export function diffAgentBOMCommand(
   oldFilePath: string,
@@ -13,39 +13,13 @@ export function diffAgentBOMCommand(
   const oldPath = resolve(oldFilePath);
   const newPath = resolve(newFilePath);
 
-  let oldRaw: string;
-  try {
-    oldRaw = readFileSync(oldPath, "utf-8");
-  } catch {
-    console.error(`Error: cannot read file "${oldPath}"`);
-    return 1;
-  }
+  const oldFile = readArtifactFile(oldPath);
+  if (oldFile.error) return oldFile.error;
 
-  let newRaw: string;
-  try {
-    newRaw = readFileSync(newPath, "utf-8");
-  } catch {
-    console.error(`Error: cannot read file "${newPath}"`);
-    return 1;
-  }
+  const newFile = readArtifactFile(newPath);
+  if (newFile.error) return newFile.error;
 
-  let oldData: unknown;
-  try {
-    oldData = JSON.parse(oldRaw);
-  } catch {
-    console.error(`Error: "${oldPath}" is not valid JSON`);
-    return 1;
-  }
-
-  let newData: unknown;
-  try {
-    newData = JSON.parse(newRaw);
-  } catch {
-    console.error(`Error: "${newPath}" is not valid JSON`);
-    return 1;
-  }
-
-  const oldResult = validateAgentBOM(oldData);
+  const oldResult = validateAgentBOM(oldFile.data);
   if (!oldResult.valid) {
     console.error(`Validation failed for old file "${oldPath}":`);
     for (const err of oldResult.errors) {
@@ -54,7 +28,7 @@ export function diffAgentBOMCommand(
     return 1;
   }
 
-  const newResult = validateAgentBOM(newData);
+  const newResult = validateAgentBOM(newFile.data);
   if (!newResult.valid) {
     console.error(`Validation failed for new file "${newPath}":`);
     for (const err of newResult.errors) {
@@ -63,9 +37,7 @@ export function diffAgentBOMCommand(
     return 1;
   }
 
-  const oldBom = oldData as Record<string, unknown>;
-  const newBom = newData as Record<string, unknown>;
-  const diff = diffAgentBOM(oldBom, newBom);
+  const diff = diffAgentBOM(oldFile.data, newFile.data);
 
   console.log("Comparing AgentBOMs:");
   console.log(`  old: ${oldPath}`);

--- a/packages/agentbom-cli/src/agentbom-validate.test.ts
+++ b/packages/agentbom-cli/src/agentbom-validate.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateAgentBOMCommand } from "./agentbom-validate.js";
+
+describe("agentbom validate command", () => {
+  let originalConsoleLog: typeof console.log;
+  let originalConsoleError: typeof console.error;
+  let consoleOutput: string[] = [];
+  let errorOutput: string[] = [];
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalConsoleLog = console.log;
+    originalConsoleError = console.error;
+    consoleOutput = [];
+    errorOutput = [];
+
+    console.log = (...args: unknown[]) => {
+      consoleOutput.push(args.map(String).join(" "));
+    };
+    console.error = (...args: unknown[]) => {
+      errorOutput.push(args.map(String).join(" "));
+    };
+
+    tempDir = mkdtempSync(join(tmpdir(), "agentbom-validate-"));
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeTempFile(name: string, content: string): string {
+    const path = join(tempDir, name);
+    writeFileSync(path, content, "utf-8");
+    return path;
+  }
+
+  it("accepts a valid AgentBOM document", () => {
+    const path = writeTempFile(
+      "valid.json",
+      JSON.stringify({
+        agentbom_version: "0.1",
+        identity: {
+          agent_id: "validate-agent-001",
+          agent_name: "Validate Agent",
+          agent_version: "1.0.0",
+          generated_at: "2026-08-01T00:00:00Z",
+        },
+        attestation: {
+          generator: "test",
+          generator_version: "0.0.1",
+        },
+      }),
+    );
+
+    const exitCode = validateAgentBOMCommand(path);
+
+    expect(exitCode).toBe(0);
+    expect(errorOutput).toHaveLength(0);
+    expect(consoleOutput[0]).toContain("Valid AgentBOM v0.1");
+  });
+
+  it("rejects an invalid AgentBOM document with error details", () => {
+    const path = writeTempFile(
+      "invalid.json",
+      JSON.stringify({ agentbom_version: "0.1" }),
+    );
+
+    const exitCode = validateAgentBOMCommand(path);
+
+    expect(exitCode).toBe(1);
+    expect(errorOutput[0]).toContain("Validation failed");
+    expect(errorOutput.join("\n")).toContain("  - ");
+  });
+
+  it("rejects a file that is not valid JSON", () => {
+    const path = writeTempFile("broken.json", "{not json");
+
+    const exitCode = validateAgentBOMCommand(path);
+
+    expect(exitCode).toBe(1);
+    expect(errorOutput.join("\n")).toContain("is not valid JSON");
+  });
+
+  it("rejects a missing file", () => {
+    const exitCode = validateAgentBOMCommand(
+      join(tempDir, "does-not-exist.json"),
+    );
+
+    expect(exitCode).toBe(1);
+    expect(errorOutput.join("\n")).toContain("cannot read file");
+  });
+});

--- a/packages/agentbom-cli/src/agentbom-validate.ts
+++ b/packages/agentbom-cli/src/agentbom-validate.ts
@@ -1,11 +1,11 @@
-import { validateMCPPosture } from "@wasmagent/mcp-posture";
+import { validateAgentBOM } from "@wasmagent/agentbom-core";
 import { readArtifactFile } from "./trust-publish.js";
 
-export function validateMCPPostureCommand(filePath: string): number {
+export function validateAgentBOMCommand(filePath: string): number {
   const { data, error } = readArtifactFile(filePath);
   if (error) return error;
 
-  const result = validateMCPPosture(data);
+  const result = validateAgentBOM(data);
   if (!result.valid) {
     console.error(`Validation failed for "${filePath}":`);
     for (const err of result.errors) {
@@ -14,6 +14,6 @@ export function validateMCPPostureCommand(filePath: string): number {
     return 1;
   }
 
-  console.log(`Valid MCP Posture v${data.posture_version}`);
+  console.log(`Valid AgentBOM v${data.agentbom_version}`);
   return 0;
 }

--- a/packages/agentbom-cli/src/compliance-check.test.ts
+++ b/packages/agentbom-cli/src/compliance-check.test.ts
@@ -267,7 +267,7 @@ describe("compliance-check: profile validation with fixtures", () => {
 
       expect(exitCode).toBe(1);
       expect(
-        errorOutput.some((line) => line.includes("cannot read AgentBOM file")),
+        errorOutput.some((line) => line.includes("cannot read file")),
       ).toBe(true);
     });
 

--- a/packages/agentbom-cli/src/compliance-check.ts
+++ b/packages/agentbom-cli/src/compliance-check.ts
@@ -3,75 +3,14 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   type CompatibilityProfileInput,
+  type ComplianceProfile,
+  checkCompliance,
   checkProfileSchemaCompatibility,
   getLatestVersion,
   upgradeProfileMappings,
   validateAgentBOM,
 } from "@wasmagent/agentbom-core";
-
-interface ComplianceResult {
-  compliant: boolean;
-  profile_id: string;
-  framework_name: string;
-  framework_version: string;
-  score: number;
-  threshold: number;
-  errors: string[];
-  warnings: string[];
-  passed_checks: string[];
-}
-
-interface ComplianceProfile {
-  profile_version: string;
-  profile_id: string;
-  framework: {
-    name: string;
-    version: string;
-    description?: string;
-  };
-  rules: {
-    identity?: {
-      weight?: number;
-      required_fields?: string[];
-      allowed_contexts?: string[];
-      requires_version?: boolean;
-    };
-    tool_layer?: {
-      weight?: number;
-      max_severity?: "low" | "medium" | "high" | "critical";
-      requires_tool_inventory?: boolean;
-      blocked_permissions?: string[];
-      blocked_sources?: string[];
-    };
-    risk_layer?: {
-      weight?: number;
-      requires_risk_assessment?: boolean;
-      max_unmitigated_critical?: number;
-      max_unmitigated_high?: number;
-      max_unmitigated_medium?: number;
-      requires_mitigation_for?: ("critical" | "high" | "medium" | "low")[];
-    };
-    attestation?: {
-      weight?: number;
-      requires_signature?: boolean;
-      requires_timestamp?: boolean;
-    };
-  };
-  metadata?: {
-    author?: string;
-    created_at?: string;
-    updated_at?: string;
-    documentation_url?: string;
-  };
-}
-
-const DEFAULT_RULE_WEIGHT = 1;
-
-const SEVERITY_ORDER = { critical: 4, high: 3, medium: 2, low: 1 };
-
-function severityLevel(severity: string): number {
-  return SEVERITY_ORDER[severity as keyof typeof SEVERITY_ORDER] || 0;
-}
+import { readArtifactFile } from "./trust-publish.js";
 
 function loadProfile(profileId: string): ComplianceProfile | null {
   const profilesDir = resolve(
@@ -89,390 +28,50 @@ function loadProfile(profileId: string): ComplianceProfile | null {
   }
 }
 
-function checkIdentity(
-  data: Record<string, unknown>,
+/** Map a compliance profile onto the schema-compatibility checker input. */
+function toCompatibilityProfileInput(
   profile: ComplianceProfile,
-): { errors: string[]; warnings: string[]; passed: string[] } {
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  const passed: string[] = [];
-
-  const identity = data.identity as Record<string, unknown> | undefined;
-
-  if (!identity) {
-    errors.push("identity section is missing");
-    return { errors, warnings, passed };
-  }
-
-  const rules = profile.rules.identity;
-  if (!rules) {
-    passed.push("identity: no rules defined");
-    return { errors, warnings, passed };
-  }
-
-  // Check required fields
-  if (rules.required_fields) {
-    for (const field of rules.required_fields) {
-      if (
-        !(field in identity) ||
-        identity[field] === undefined ||
-        identity[field] === null
-      ) {
-        errors.push(`identity: missing required field "${field}"`);
-      } else {
-        passed.push(`identity: field "${field}" present`);
-      }
-    }
-  }
-
-  // Check allowed contexts
-  if (rules.allowed_contexts && rules.allowed_contexts.length > 0) {
-    const context = String(identity.deployment_context ?? "");
-    if (!rules.allowed_contexts.includes(context)) {
-      errors.push(
-        `identity: deployment_context "${context}" not in allowed contexts [${rules.allowed_contexts.join(", ")}]`,
-      );
-    } else {
-      passed.push(`identity: deployment_context "${context}" is allowed`);
-    }
-  }
-
-  // Check version requirement
-  if (rules.requires_version) {
-    if (
-      !identity.agent_version ||
-      String(identity.agent_version).trim() === ""
-    ) {
-      errors.push("identity: agent_version is required but missing or empty");
-    } else {
-      passed.push(
-        `identity: agent_version "${identity.agent_version}" present`,
-      );
-    }
-  }
-
-  return { errors, warnings, passed };
-}
-
-function checkToolLayer(
-  data: Record<string, unknown>,
-  profile: ComplianceProfile,
-): { errors: string[]; warnings: string[]; passed: string[] } {
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  const passed: string[] = [];
-
-  const toolLayer = data.tool_layer as unknown[] | undefined;
-
-  const rules = profile.rules.tool_layer;
-  if (!rules) {
-    passed.push("tool_layer: no rules defined");
-    return { errors, warnings, passed };
-  }
-
-  // Check tool inventory requirement
-  if (rules.requires_tool_inventory) {
-    if (!toolLayer || toolLayer.length === 0) {
-      errors.push(
-        "tool_layer: tool inventory is required but missing or empty",
-      );
-    } else {
-      passed.push(
-        `tool_layer: tool inventory present (${toolLayer.length} tools)`,
-      );
-    }
-  }
-
-  if (!toolLayer || toolLayer.length === 0) {
-    return { errors, warnings, passed };
-  }
-
-  // Check each tool for max severity
-  if (rules.max_severity) {
-    const maxLevel = severityLevel(rules.max_severity);
-    for (const tool of toolLayer) {
-      if (typeof tool === "object" && tool !== null) {
-        const t = tool as Record<string, unknown>;
-        const riskSignals = t.risk_signals as string[] | undefined;
-        if (riskSignals) {
-          for (const signal of riskSignals) {
-            const severity = signal.split(":")[0]?.toLowerCase();
-            if (severity && severityLevel(severity) > maxLevel) {
-              errors.push(
-                `tool_layer: tool "${t.tool_name}" has risk signal "${signal}" exceeding max severity "${rules.max_severity}"`,
-              );
-            }
+): CompatibilityProfileInput {
+  return {
+    profile_version: profile.profile_version,
+    rules: {
+      identity: profile.rules.identity
+        ? {
+            required_fields: profile.rules.identity.required_fields,
+            allowed_contexts: profile.rules.identity.allowed_contexts,
+            requires_version: profile.rules.identity.requires_version,
           }
-        }
-      }
-    }
-    if (errors.filter((e) => e.startsWith("tool_layer: tool")).length === 0) {
-      passed.push(
-        `tool_layer: all tools within max severity "${rules.max_severity}"`,
-      );
-    }
-  }
-
-  // Check blocked permissions
-  if (rules.blocked_permissions && rules.blocked_permissions.length > 0) {
-    const blockedPermissions = rules.blocked_permissions;
-    for (const tool of toolLayer) {
-      if (typeof tool === "object" && tool !== null) {
-        const t = tool as Record<string, unknown>;
-        const permissions = t.permissions as string[] | undefined;
-        if (permissions) {
-          for (const perm of permissions) {
-            for (const blocked of blockedPermissions) {
-              if (perm.toLowerCase().includes(blocked.toLowerCase())) {
-                errors.push(
-                  `tool_layer: tool "${t.tool_name}" has blocked permission "${perm}" (matches "${blocked}")`,
-                );
-              }
-            }
+        : undefined,
+      tool_layer: profile.rules.tool_layer
+        ? {
+            max_severity: profile.rules.tool_layer.max_severity,
+            requires_tool_inventory:
+              profile.rules.tool_layer.requires_tool_inventory,
+            blocked_permissions: profile.rules.tool_layer.blocked_permissions,
+            blocked_sources: profile.rules.tool_layer.blocked_sources,
           }
-        }
-      }
-    }
-  }
-
-  // Check blocked sources
-  if (rules.blocked_sources && rules.blocked_sources.length > 0) {
-    const blockedSources = rules.blocked_sources;
-    for (const tool of toolLayer) {
-      if (typeof tool === "object" && tool !== null) {
-        const t = tool as Record<string, unknown>;
-        const source = String(t.source ?? "");
-        for (const blocked of blockedSources) {
-          if (source.toLowerCase().includes(blocked.toLowerCase())) {
-            errors.push(
-              `tool_layer: tool "${t.tool_name}" has blocked source "${source}"`,
-            );
+        : undefined,
+      risk_layer: profile.rules.risk_layer
+        ? {
+            requires_risk_assessment:
+              profile.rules.risk_layer.requires_risk_assessment,
+            max_unmitigated_critical:
+              profile.rules.risk_layer.max_unmitigated_critical,
+            max_unmitigated_high: profile.rules.risk_layer.max_unmitigated_high,
+            max_unmitigated_medium:
+              profile.rules.risk_layer.max_unmitigated_medium,
+            requires_mitigation_for:
+              profile.rules.risk_layer.requires_mitigation_for,
           }
-        }
-      }
-    }
-  }
-
-  if (errors.filter((e) => e.startsWith("tool_layer:")).length === 0) {
-    passed.push("tool_layer: no blocked permissions or sources found");
-  }
-
-  return { errors, warnings, passed };
-}
-
-function checkRiskLayer(
-  data: Record<string, unknown>,
-  profile: ComplianceProfile,
-): { errors: string[]; warnings: string[]; passed: string[] } {
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  const passed: string[] = [];
-
-  const riskLayer = data.risk_layer as unknown[] | undefined;
-
-  const rules = profile.rules.risk_layer;
-  if (!rules) {
-    passed.push("risk_layer: no rules defined");
-    return { errors, warnings, passed };
-  }
-
-  // Check risk assessment requirement
-  if (rules.requires_risk_assessment) {
-    if (!riskLayer || riskLayer.length === 0) {
-      errors.push(
-        "risk_layer: risk assessment is required but missing or empty",
-      );
-    } else {
-      passed.push(
-        `risk_layer: risk assessment present (${riskLayer.length} risks)`,
-      );
-    }
-  }
-
-  if (!riskLayer || riskLayer.length === 0) {
-    return { errors, warnings, passed };
-  }
-
-  // Count unmitigated risks by severity
-  const unmitigatedCounts: Record<string, number> = {
-    critical: 0,
-    high: 0,
-    medium: 0,
-    low: 0,
+        : undefined,
+      attestation: profile.rules.attestation
+        ? {
+            requires_signature: profile.rules.attestation.requires_signature,
+            requires_timestamp: profile.rules.attestation.requires_timestamp,
+          }
+        : undefined,
+    },
   };
-
-  for (const risk of riskLayer) {
-    if (typeof risk === "object" && risk !== null) {
-      const r = risk as Record<string, unknown>;
-      const severity = String(r.severity ?? "").toLowerCase();
-      const status = String(r.status ?? "").toLowerCase();
-
-      if (status !== "mitigated" && status !== "accepted") {
-        if (severity in unmitigatedCounts) {
-          unmitigatedCounts[severity]++;
-        }
-      }
-    }
-  }
-
-  // Check max unmitigated critical
-  if (rules.max_unmitigated_critical !== undefined) {
-    const count = unmitigatedCounts.critical;
-    if (count > rules.max_unmitigated_critical) {
-      errors.push(
-        `risk_layer: ${count} unmitigated critical risks (max allowed: ${rules.max_unmitigated_critical})`,
-      );
-    } else {
-      passed.push(
-        `risk_layer: unmitigated critical risks within limit (${count}/${rules.max_unmitigated_critical})`,
-      );
-    }
-  }
-
-  // Check max unmitigated high
-  if (rules.max_unmitigated_high !== undefined) {
-    const count = unmitigatedCounts.high;
-    if (count > rules.max_unmitigated_high) {
-      errors.push(
-        `risk_layer: ${count} unmitigated high risks (max allowed: ${rules.max_unmitigated_high})`,
-      );
-    } else {
-      passed.push(
-        `risk_layer: unmitigated high risks within limit (${count}/${rules.max_unmitigated_high})`,
-      );
-    }
-  }
-
-  // Check max unmitigated medium
-  if (rules.max_unmitigated_medium !== undefined) {
-    const count = unmitigatedCounts.medium;
-    if (count > rules.max_unmitigated_medium) {
-      errors.push(
-        `risk_layer: ${count} unmitigated medium risks (max allowed: ${rules.max_unmitigated_medium})`,
-      );
-    } else {
-      passed.push(
-        `risk_layer: unmitigated medium risks within limit (${count}/${rules.max_unmitigated_medium})`,
-      );
-    }
-  }
-
-  // Check mitigation requirements
-  if (
-    rules.requires_mitigation_for &&
-    rules.requires_mitigation_for.length > 0
-  ) {
-    for (const risk of riskLayer) {
-      if (typeof risk === "object" && risk !== null) {
-        const r = risk as Record<string, unknown>;
-        const severity = String(r.severity ?? "").toLowerCase();
-        const status = String(r.status ?? "").toLowerCase();
-
-        if (
-          rules.requires_mitigation_for?.includes(
-            severity as "critical" | "high" | "medium" | "low",
-          )
-        ) {
-          if (status !== "mitigated" && status !== "accepted") {
-            warnings.push(
-              `risk_layer: risk "${r.risk_id}" has severity "${severity}" without mitigation status`,
-            );
-          }
-        }
-      }
-    }
-  }
-
-  return { errors, warnings, passed };
-}
-
-function checkAttestation(
-  data: Record<string, unknown>,
-  profile: ComplianceProfile,
-): { errors: string[]; warnings: string[]; passed: string[] } {
-  const errors: string[] = [];
-  const warnings: string[] = [];
-  const passed: string[] = [];
-
-  const attestation = data.attestation as Record<string, unknown> | undefined;
-
-  if (!attestation) {
-    errors.push("attestation section is missing");
-    return { errors, warnings, passed };
-  }
-
-  const rules = profile.rules.attestation;
-  if (!rules) {
-    passed.push("attestation: no rules defined");
-    return { errors, warnings, passed };
-  }
-
-  // Check signature requirement
-  if (rules.requires_signature) {
-    const signature = attestation.signature;
-    if (!signature || String(signature).trim() === "") {
-      errors.push("attestation: signature is required but missing or empty");
-    } else {
-      passed.push("attestation: signature present");
-    }
-  }
-
-  // Check timestamp requirement
-  if (rules.requires_timestamp) {
-    const timestamp = attestation.timestamp;
-    if (!timestamp || String(timestamp).trim() === "") {
-      errors.push("attestation: timestamp is required but missing or empty");
-    } else {
-      passed.push("attestation: timestamp present");
-    }
-  }
-
-  return { errors, warnings, passed };
-}
-
-/**
- * Compute a weighted compliance score from check results.
- *
- * Each rule section (identity, tool_layer, risk_layer, attestation) can carry
- * an optional `weight` (float ≥ 0).  The default weight for any section is 1.
- *
- * A section is considered *passing* if it produced no errors.
- * The score is the fraction:
- *
- *   score = Σ(weight_i for passing sections) / Σ(weight_i for all sections)
- *
- * Returns a value in [0, 1] where 1 means every enabled rule section passed.
- */
-function computeWeightedScore(
-  checkResults: { errors: string[]; warnings: string[]; passed: string[] }[],
-  profile: ComplianceProfile,
-): number {
-  const ruleKeys: (keyof typeof profile.rules)[] = [
-    "identity",
-    "tool_layer",
-    "risk_layer",
-    "attestation",
-  ];
-  let totalWeight = 0;
-  let passedWeight = 0;
-
-  for (let i = 0; i < ruleKeys.length; i++) {
-    const key = ruleKeys[i];
-    const section = profile.rules[key];
-    const weight =
-      section && typeof section === "object" && "weight" in section
-        ? ((section as { weight?: number }).weight ?? DEFAULT_RULE_WEIGHT)
-        : DEFAULT_RULE_WEIGHT;
-
-    if (weight <= 0) continue; // Skip zero-weight sections
-
-    totalWeight += weight;
-    if (checkResults[i].errors.length === 0) {
-      passedWeight += weight;
-    }
-  }
-
-  return totalWeight > 0 ? passedWeight / totalWeight : 1;
 }
 
 export function complianceCheckCommand(args: string[]): number {
@@ -519,21 +118,8 @@ export function complianceCheckCommand(args: string[]): number {
 
   // Load AgentBOM
   const resolvedBomPath = resolve(bomPath);
-  let bomRaw: string;
-  try {
-    bomRaw = readFileSync(resolvedBomPath, "utf-8");
-  } catch {
-    console.error(`Error: cannot read AgentBOM file "${resolvedBomPath}"`);
-    return 1;
-  }
-
-  let bomData: unknown;
-  try {
-    bomData = JSON.parse(bomRaw);
-  } catch {
-    console.error(`Error: "${resolvedBomPath}" is not valid JSON`);
-    return 1;
-  }
+  const { data: bomData, error } = readArtifactFile(resolvedBomPath);
+  if (error) return error;
 
   // Validate AgentBOM schema
   const bomValidation = validateAgentBOM(bomData);
@@ -556,33 +142,8 @@ export function complianceCheckCommand(args: string[]): number {
   }
 
   // Run compliance checks
-  const checks = [
-    checkIdentity(bomData as Record<string, unknown>, profile),
-    checkToolLayer(bomData as Record<string, unknown>, profile),
-    checkRiskLayer(bomData as Record<string, unknown>, profile),
-    checkAttestation(bomData as Record<string, unknown>, profile),
-  ];
-
-  // Compute weighted score
-  const score = computeWeightedScore(checks, profile);
-
-  const result: ComplianceResult = {
-    compliant: score >= minScore,
-    profile_id: profile.profile_id,
-    framework_name: profile.framework.name,
-    framework_version: profile.framework.version,
-    score,
-    threshold: minScore,
-    errors: [],
-    warnings: [],
-    passed_checks: [],
-  };
-
-  for (const check of checks) {
-    result.errors.push(...check.errors);
-    result.warnings.push(...check.warnings);
-    result.passed_checks.push(...check.passed);
-  }
+  const result = checkCompliance(bomData, profile, minScore);
+  const score = result.score;
 
   // Output results
   console.log(
@@ -665,48 +226,10 @@ export function verifyProfileCommand(args: string[]): number {
     return 1;
   }
 
-  const input: CompatibilityProfileInput = {
-    profile_version: profile.profile_version,
-    rules: {
-      identity: profile.rules.identity
-        ? {
-            required_fields: profile.rules.identity.required_fields,
-            allowed_contexts: profile.rules.identity.allowed_contexts,
-            requires_version: profile.rules.identity.requires_version,
-          }
-        : undefined,
-      tool_layer: profile.rules.tool_layer
-        ? {
-            max_severity: profile.rules.tool_layer.max_severity,
-            requires_tool_inventory:
-              profile.rules.tool_layer.requires_tool_inventory,
-            blocked_permissions: profile.rules.tool_layer.blocked_permissions,
-            blocked_sources: profile.rules.tool_layer.blocked_sources,
-          }
-        : undefined,
-      risk_layer: profile.rules.risk_layer
-        ? {
-            requires_risk_assessment:
-              profile.rules.risk_layer.requires_risk_assessment,
-            max_unmitigated_critical:
-              profile.rules.risk_layer.max_unmitigated_critical,
-            max_unmitigated_high: profile.rules.risk_layer.max_unmitigated_high,
-            max_unmitigated_medium:
-              profile.rules.risk_layer.max_unmitigated_medium,
-            requires_mitigation_for:
-              profile.rules.risk_layer.requires_mitigation_for,
-          }
-        : undefined,
-      attestation: profile.rules.attestation
-        ? {
-            requires_signature: profile.rules.attestation.requires_signature,
-            requires_timestamp: profile.rules.attestation.requires_timestamp,
-          }
-        : undefined,
-    },
-  };
-
-  const result = checkProfileSchemaCompatibility(input, schemaVersion);
+  const result = checkProfileSchemaCompatibility(
+    toCompatibilityProfileInput(profile),
+    schemaVersion,
+  );
 
   console.log(`Profile Compatibility Check: ${profileId}`);
   console.log(`  Profile version:   ${result.profile_version}`);
@@ -812,48 +335,10 @@ export function upgradeProfileCommand(args: string[]): number {
     return 1;
   }
 
-  const input: CompatibilityProfileInput = {
-    profile_version: profile.profile_version,
-    rules: {
-      identity: profile.rules.identity
-        ? {
-            required_fields: profile.rules.identity.required_fields,
-            allowed_contexts: profile.rules.identity.allowed_contexts,
-            requires_version: profile.rules.identity.requires_version,
-          }
-        : undefined,
-      tool_layer: profile.rules.tool_layer
-        ? {
-            max_severity: profile.rules.tool_layer.max_severity,
-            requires_tool_inventory:
-              profile.rules.tool_layer.requires_tool_inventory,
-            blocked_permissions: profile.rules.tool_layer.blocked_permissions,
-            blocked_sources: profile.rules.tool_layer.blocked_sources,
-          }
-        : undefined,
-      risk_layer: profile.rules.risk_layer
-        ? {
-            requires_risk_assessment:
-              profile.rules.risk_layer.requires_risk_assessment,
-            max_unmitigated_critical:
-              profile.rules.risk_layer.max_unmitigated_critical,
-            max_unmitigated_high: profile.rules.risk_layer.max_unmitigated_high,
-            max_unmitigated_medium:
-              profile.rules.risk_layer.max_unmitigated_medium,
-            requires_mitigation_for:
-              profile.rules.risk_layer.requires_mitigation_for,
-          }
-        : undefined,
-      attestation: profile.rules.attestation
-        ? {
-            requires_signature: profile.rules.attestation.requires_signature,
-            requires_timestamp: profile.rules.attestation.requires_timestamp,
-          }
-        : undefined,
-    },
-  };
-
-  const result = upgradeProfileMappings(input, schemaVersion);
+  const result = upgradeProfileMappings(
+    toCompatibilityProfileInput(profile),
+    schemaVersion,
+  );
 
   console.log(`Profile Upgrade: ${profileId}`);
   console.log(`  Profile version:   ${result.compatibility.profile_version}`);

--- a/packages/agentbom-cli/src/index.ts
+++ b/packages/agentbom-cli/src/index.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env bun
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import {
   getLatestVersion as getLatestAgentBOMVersion,
   getSupportedVersions as getSupportedAgentBOMVersions,
@@ -14,6 +12,7 @@ import {
 import { diffAgentBOMCommand } from "./agentbom-diff.js";
 import { inspectAgentBOMCommand } from "./agentbom-inspect.js";
 import { agentbomPipelineCommand } from "./agentbom-pipeline.js";
+import { validateAgentBOMCommand } from "./agentbom-validate.js";
 import { auditReportCommand } from "./audit-report.js";
 import { generateAgentBOMCommand } from "./bom-generate.js";
 import { chainCommand } from "./chain.js";
@@ -35,7 +34,7 @@ import { verifySignedPassportCommand } from "./passport-verify-signed.js";
 import { reportCommand } from "./regulatory-report.js";
 import { verifySigstoreCommand } from "./sigstore-verify.js";
 import { trustDiffCommand } from "./trust-diff.js";
-import { publishCommand } from "./trust-publish.js";
+import { publishCommand, readArtifactFile } from "./trust-publish.js";
 import { pullCommand } from "./trust-pull.js";
 import { subscribeCommand } from "./trust-subscribe.js";
 import { verifyChainCommand } from "./trust-verify-chain.js";
@@ -51,6 +50,7 @@ const USAGE = [
   "  passport verify-signed <jwt-path> [--key <pubkey>]  Verify a signed passport JWT",
   "  passport verify-sigstore <bundle.json> [--artifact <path>] [--offline] [--fips] [--issuer <url>]  Verify with Sigstore bundle",
   "  agentbom inspect <path>    Inspect an AgentBOM file",
+  "  agentbom validate <path>   Validate an AgentBOM file",
   "  agentbom diff <old> <new>  Diff two AgentBOM files",
   "  agentbom pipeline <path> [--partitions N] [--no-incremental]  Stream-process BOM artifacts",
   "  agentbom generate --agent <path>  Generate AgentBOM JSON from agent directory",
@@ -102,131 +102,102 @@ function parseMigrateArgs(args: string[]): {
   return { filePath, target, dryRun };
 }
 
-/** Read and parse a JSON file, returning an error code on failure. */
-function readJsonFile(filePath: string): {
+/** Result shape shared by the AgentBOM and MCP Posture migrators. */
+interface MigrationOutcome {
+  success: boolean;
   data: Record<string, unknown>;
-  error: number;
-} {
-  const resolved = resolve(filePath);
-  let raw: string;
-  try {
-    raw = readFileSync(resolved, "utf-8");
-  } catch {
-    console.error(`Error: cannot read file "${resolved}"`);
-    return { data: {}, error: 1 };
+  stepsApplied: {
+    fromVersion: string;
+    toVersion: string;
+    description: string;
+    breaking?: boolean;
+  }[];
+  warnings: string[];
+  errors: string[];
+}
+
+/** Run a schema-migration command (shared by agentbom and mcp-posture). */
+function runMigrateCommand(
+  args: string[],
+  opts: {
+    label: string;
+    commandName: string;
+    latestVersion: string;
+    supportedVersions: string[];
+    versionKey: string;
+    migrate: (
+      data: Record<string, unknown>,
+      target?: string,
+    ) => MigrationOutcome;
+  },
+): number {
+  const { filePath, target, dryRun } = parseMigrateArgs(args);
+  if (!filePath) {
+    console.error(`Error: ${opts.commandName} requires a <path> argument`);
+    return 1;
   }
-  let data: unknown;
-  try {
-    data = JSON.parse(raw);
-  } catch {
-    console.error(`Error: "${resolved}" is not valid JSON`);
-    return { data: {}, error: 1 };
+
+  const { data, error } = readArtifactFile(filePath);
+  if (error) return error;
+
+  const latest = `v${opts.latestVersion} (latest)`;
+  console.log(
+    `${opts.label} migration: v${data[opts.versionKey] ?? "unknown"} → ${target ?? latest}`,
+  );
+  console.log(`  Supported versions: ${opts.supportedVersions.join(", ")}`);
+
+  const result = opts.migrate(data, target);
+
+  if (!result.success) {
+    console.error("  Migration failed:");
+    for (const e of result.errors) console.error(`    - ${e}`);
+    return 1;
   }
-  if (typeof data !== "object" || data === null || Array.isArray(data)) {
-    console.error(`Error: "${resolved}" does not contain a JSON object`);
-    return { data: {}, error: 1 };
+
+  if (result.stepsApplied.length === 0) {
+    console.log("  Already at target version — no migration needed.");
+  } else {
+    for (const step of result.stepsApplied) {
+      const breaking = step.breaking ? " (breaking)" : "";
+      console.log(
+        `  Step: ${step.fromVersion} → ${step.toVersion}: ${step.description}${breaking}`,
+      );
+    }
   }
-  return { data: data as Record<string, unknown>, error: 0 };
+
+  for (const w of result.warnings) {
+    console.warn(`  Warning: ${w}`);
+  }
+
+  if (dryRun) {
+    console.log("  (dry-run — no output written)");
+    return 0;
+  }
+
+  console.log(JSON.stringify(result.data, null, 2));
+  return 0;
 }
 
 function agentbomMigrateCommand(args: string[]): number {
-  const { filePath, target, dryRun } = parseMigrateArgs(args);
-  if (!filePath) {
-    console.error("Error: agentbom migrate requires a <path> argument");
-    return 1;
-  }
-
-  const { data, error } = readJsonFile(filePath);
-  if (error) return error;
-
-  const agentbomLatest = `v${getLatestAgentBOMVersion()} (latest)`;
-  console.log(
-    `AgentBOM migration: v${data.agentbom_version ?? "unknown"} → ${target ?? agentbomLatest}`,
-  );
-  console.log(
-    `  Supported versions: ${getSupportedAgentBOMVersions().join(", ")}`,
-  );
-
-  const result = migrateAgentBOM(data, target);
-
-  if (!result.success) {
-    console.error("  Migration failed:");
-    for (const e of result.errors) console.error(`    - ${e}`);
-    return 1;
-  }
-
-  if (result.stepsApplied.length === 0) {
-    console.log("  Already at target version — no migration needed.");
-  } else {
-    for (const step of result.stepsApplied) {
-      const breaking = step.breaking ? " (breaking)" : "";
-      console.log(
-        `  Step: ${step.fromVersion} → ${step.toVersion}: ${step.description}${breaking}`,
-      );
-    }
-  }
-
-  for (const w of result.warnings) {
-    console.warn(`  Warning: ${w}`);
-  }
-
-  if (dryRun) {
-    console.log("  (dry-run — no output written)");
-    return 0;
-  }
-
-  console.log(JSON.stringify(result.data, null, 2));
-  return 0;
+  return runMigrateCommand(args, {
+    label: "AgentBOM",
+    commandName: "agentbom migrate",
+    latestVersion: getLatestAgentBOMVersion(),
+    supportedVersions: getSupportedAgentBOMVersions(),
+    versionKey: "agentbom_version",
+    migrate: migrateAgentBOM,
+  });
 }
 
 function postureMigrateCommand(args: string[]): number {
-  const { filePath, target, dryRun } = parseMigrateArgs(args);
-  if (!filePath) {
-    console.error("Error: mcp-posture migrate requires a <path> argument");
-    return 1;
-  }
-
-  const { data, error } = readJsonFile(filePath);
-  if (error) return error;
-
-  const postureLatest = `v${getLatestPostureVersion()} (latest)`;
-  console.log(
-    `MCP Posture migration: v${data.posture_version ?? "unknown"} → ${target ?? postureLatest}`,
-  );
-  console.log(
-    `  Supported versions: ${getSupportedPostureVersions().join(", ")}`,
-  );
-
-  const result = migrateMCPPosture(data, target);
-
-  if (!result.success) {
-    console.error("  Migration failed:");
-    for (const e of result.errors) console.error(`    - ${e}`);
-    return 1;
-  }
-
-  if (result.stepsApplied.length === 0) {
-    console.log("  Already at target version — no migration needed.");
-  } else {
-    for (const step of result.stepsApplied) {
-      const breaking = step.breaking ? " (breaking)" : "";
-      console.log(
-        `  Step: ${step.fromVersion} → ${step.toVersion}: ${step.description}${breaking}`,
-      );
-    }
-  }
-
-  for (const w of result.warnings) {
-    console.warn(`  Warning: ${w}`);
-  }
-
-  if (dryRun) {
-    console.log("  (dry-run — no output written)");
-    return 0;
-  }
-
-  console.log(JSON.stringify(result.data, null, 2));
-  return 0;
+  return runMigrateCommand(args, {
+    label: "MCP Posture",
+    commandName: "mcp-posture migrate",
+    latestVersion: getLatestPostureVersion(),
+    supportedVersions: getSupportedPostureVersions(),
+    versionKey: "posture_version",
+    migrate: migrateMCPPosture,
+  });
 }
 
 // --- Policy enforcement engine (mirrors cmd/policy-engine/main.go) ---
@@ -604,10 +575,11 @@ function enforcePolicyCommand(args: string[]): number {
     return 1;
   }
 
-  const { data: policyData, error: policyErr } = readJsonFile(policyPath);
+  const { data: policyData, error: policyErr } = readArtifactFile(policyPath);
   if (policyErr) return policyErr;
 
-  const { data: artifactData, error: artifactErr } = readJsonFile(artifactPath);
+  const { data: artifactData, error: artifactErr } =
+    readArtifactFile(artifactPath);
   if (artifactErr) return artifactErr;
 
   const policy = policyData as unknown as PolicyDocument;
@@ -717,6 +689,13 @@ export function runCommand(args: string[]): number | Promise<number> {
         return 1;
       }
       return inspectAgentBOMCommand(args[2]);
+    }
+    if (args[1] === "validate") {
+      if (args.length < 3) {
+        console.error("Error: agentbom validate requires a <path> argument");
+        return 1;
+      }
+      return validateAgentBOMCommand(args[2]);
     }
     if (args[1] === "diff") {
       if (args.length < 4) {

--- a/packages/agentbom-cli/src/mcp-posture-diff.ts
+++ b/packages/agentbom-cli/src/mcp-posture-diff.ts
@@ -1,10 +1,10 @@
-import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   diffMCPPosture,
   formatPostureDiff,
   validateMCPPosture,
 } from "@wasmagent/mcp-posture";
+import { readArtifactFile } from "./trust-publish.js";
 
 export function diffMCPPostureCommand(
   oldFilePath: string,
@@ -13,39 +13,13 @@ export function diffMCPPostureCommand(
   const oldPath = resolve(oldFilePath);
   const newPath = resolve(newFilePath);
 
-  let oldRaw: string;
-  try {
-    oldRaw = readFileSync(oldPath, "utf-8");
-  } catch {
-    console.error(`Error: cannot read file "${oldPath}"`);
-    return 1;
-  }
+  const oldFile = readArtifactFile(oldPath);
+  if (oldFile.error) return oldFile.error;
 
-  let newRaw: string;
-  try {
-    newRaw = readFileSync(newPath, "utf-8");
-  } catch {
-    console.error(`Error: cannot read file "${newPath}"`);
-    return 1;
-  }
+  const newFile = readArtifactFile(newPath);
+  if (newFile.error) return newFile.error;
 
-  let oldData: unknown;
-  try {
-    oldData = JSON.parse(oldRaw);
-  } catch {
-    console.error(`Error: "${oldPath}" is not valid JSON`);
-    return 1;
-  }
-
-  let newData: unknown;
-  try {
-    newData = JSON.parse(newRaw);
-  } catch {
-    console.error(`Error: "${newPath}" is not valid JSON`);
-    return 1;
-  }
-
-  const oldResult = validateMCPPosture(oldData);
+  const oldResult = validateMCPPosture(oldFile.data);
   if (!oldResult.valid) {
     console.error(`Validation failed for old file "${oldPath}":`);
     for (const err of oldResult.errors) {
@@ -54,7 +28,7 @@ export function diffMCPPostureCommand(
     return 1;
   }
 
-  const newResult = validateMCPPosture(newData);
+  const newResult = validateMCPPosture(newFile.data);
   if (!newResult.valid) {
     console.error(`Validation failed for new file "${newPath}":`);
     for (const err of newResult.errors) {
@@ -63,10 +37,7 @@ export function diffMCPPostureCommand(
     return 1;
   }
 
-  const diff = diffMCPPosture(
-    oldData as Record<string, unknown>,
-    newData as Record<string, unknown>,
-  );
+  const diff = diffMCPPosture(oldFile.data, newFile.data);
 
   console.log("Comparing MCP Posture snapshots:");
   console.log(`  old: ${oldPath}`);

--- a/packages/agentbom-cli/src/mcp-posture-inspect.ts
+++ b/packages/agentbom-cli/src/mcp-posture-inspect.ts
@@ -1,37 +1,20 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { inspectMCPPosture, validateMCPPosture } from "@wasmagent/mcp-posture";
+import { readArtifactFile } from "./trust-publish.js";
 
 export function inspectMCPPostureCommand(filePath: string): number {
-  const resolvedPath = resolve(filePath);
-
-  let raw: string;
-  try {
-    raw = readFileSync(resolvedPath, "utf-8");
-  } catch {
-    console.error(`Error: cannot read file "${resolvedPath}"`);
-    return 1;
-  }
-
-  let data: unknown;
-  try {
-    data = JSON.parse(raw);
-  } catch {
-    console.error(`Error: "${resolvedPath}" is not valid JSON`);
-    return 1;
-  }
+  const { data, error } = readArtifactFile(filePath);
+  if (error) return error;
 
   const result = validateMCPPosture(data);
   if (!result.valid) {
-    console.error(`Validation failed for "${resolvedPath}":`);
+    console.error(`Validation failed for "${filePath}":`);
     for (const err of result.errors) {
       console.error(`  - ${err}`);
     }
     return 1;
   }
 
-  const posture = data as Record<string, unknown>;
-  console.log(inspectMCPPosture(posture));
+  console.log(inspectMCPPosture(data));
 
   return 0;
 }

--- a/packages/agentbom-core/src/generate.ts
+++ b/packages/agentbom-core/src/generate.ts
@@ -1,0 +1,258 @@
+/**
+ * Shared AgentBOM manifest generator.
+ *
+ * Builds an AgentBOM v0.1 manifest from a normalized agent description.
+ * The framework adapter packages (langchain, autogen, llamaindex) map their
+ * framework-specific config types onto the input shape below and delegate
+ * here, so the manifest construction logic lives in exactly one place.
+ */
+
+// ─── Input types ─────────────────────────────────────────────────
+
+export interface AgentBOMToolInput {
+  /** Tool name (maps to `tool_id` if `id` is not supplied). */
+  name: string;
+  /** Human-readable description — used for `tool_name`. */
+  description?: string;
+  /** Optional override for the AgentBOM `tool_id`. */
+  id?: string;
+  /** AgentBOM tool source: `"mcp"` | `"builtin"` | `"plugin"`. */
+  source?: "mcp" | "builtin" | "plugin";
+  /** MCP server identifier when `source === "mcp"`. */
+  mcp_server_id?: string;
+  /** Skills this tool contributes to the agent. */
+  skills?: string[];
+  /** Permission scopes the tool requires. */
+  permissions?: string[];
+  /** Known risk signals. */
+  risk_signals?: string[];
+}
+
+export interface AgentBOMLLMInput {
+  provider: string;
+  model_id: string;
+  model_version?: string;
+  capabilities?: string[];
+}
+
+export interface AgentBOMWorkflowStepInput {
+  /** Unique step identifier within the workflow. */
+  step_id: string;
+  /** Action to perform (tool_id, prompt name, sub_workflow, or decision). */
+  action: string;
+  /** Human-readable step description. */
+  description?: string;
+  /** Step IDs this step depends on. */
+  depends_on?: string[];
+  /** Tool IDs allowed at this step. */
+  allowed_tools?: string[];
+}
+
+export interface AgentBOMWorkflowInput {
+  /** Unique workflow identifier. */
+  workflow_id: string;
+  /** Human-readable workflow name. */
+  workflow_name: string;
+  /** Workflow description. */
+  description?: string;
+  /** Workflow version (semver). */
+  version?: string;
+  /** Ordered steps. */
+  steps: AgentBOMWorkflowStepInput[];
+}
+
+export interface AgentBOMGenerateInput {
+  agent_id: string;
+  agent_name: string;
+  agent_version?: string;
+  deployment_context?: "development" | "staging" | "production";
+  tools?: AgentBOMToolInput[];
+  llm?: AgentBOMLLMInput;
+  system_prompt_hash?: string;
+  prompt_version?: string;
+  template_ids?: string[];
+  granted_scopes?: string[];
+  data_access?: string[];
+  credential_references?: string[];
+  /** Workflow / action pathway definitions. */
+  workflows?: AgentBOMWorkflowInput[];
+}
+
+// ─── Output type ─────────────────────────────────────────────────
+
+/** The shape of a generated AgentBOM document. */
+export interface AgentBOMRecord {
+  agentbom_version: string;
+  identity: {
+    agent_id: string;
+    agent_name: string;
+    agent_version?: string;
+    deployment_context?: string;
+    generated_at: string;
+  };
+  model_layer?: {
+    provider: string;
+    model_id: string;
+    model_version?: string;
+    capabilities?: string[];
+  };
+  tool_layer?: Array<{
+    tool_id: string;
+    tool_name: string;
+    source: "mcp" | "builtin" | "plugin";
+    mcp_server_id?: string;
+    skills?: string[];
+    permissions?: string[];
+    risk_signals?: string[];
+  }>;
+  prompt_layer?: {
+    system_prompt_hash?: string;
+    prompt_version?: string;
+    template_ids?: string[];
+  };
+  permission_layer?: {
+    granted_scopes?: string[];
+    data_access?: string[];
+    credential_references?: string[];
+  };
+  workflow_layer?: Array<{
+    workflow_id: string;
+    workflow_name: string;
+    description?: string;
+    version?: string;
+    steps: Array<{
+      step_id: string;
+      action: string;
+      description?: string;
+      depends_on?: string[];
+      allowed_tools?: string[];
+    }>;
+  }>;
+  attestation: {
+    generator: string;
+    generator_version: string;
+  };
+}
+
+// ─── Generator ───────────────────────────────────────────────────
+
+/**
+ * Convert a normalized agent configuration into an AgentBOM v0.1 manifest.
+ *
+ * The returned object is guaranteed to include all required fields
+ * (`agentbom_version`, `identity`, `attestation`) and will validate
+ * against the canonical AgentBOM schema.
+ */
+export function buildAgentBOM(
+  config: AgentBOMGenerateInput,
+  attestation: { generator: string; generator_version: string },
+): AgentBOMRecord {
+  const now = new Date().toISOString();
+
+  const tool_layer = (config.tools ?? []).map((t) => ({
+    tool_id: t.id ?? slugify(t.name),
+    tool_name: t.description ?? t.name,
+    source: t.source ?? "builtin",
+    ...(t.mcp_server_id ? { mcp_server_id: t.mcp_server_id } : {}),
+    ...(t.skills?.length ? { skills: t.skills } : {}),
+    ...(t.permissions?.length ? { permissions: t.permissions } : {}),
+    ...(t.risk_signals?.length ? { risk_signals: t.risk_signals } : {}),
+  }));
+
+  const bom: AgentBOMRecord = {
+    agentbom_version: "0.1",
+    identity: {
+      agent_id: config.agent_id,
+      agent_name: config.agent_name,
+      ...(config.agent_version ? { agent_version: config.agent_version } : {}),
+      ...(config.deployment_context
+        ? { deployment_context: config.deployment_context }
+        : {}),
+      generated_at: now,
+    },
+    ...(config.llm
+      ? {
+          model_layer: {
+            provider: config.llm.provider,
+            model_id: config.llm.model_id,
+            ...(config.llm.model_version
+              ? { model_version: config.llm.model_version }
+              : {}),
+            ...(config.llm.capabilities?.length
+              ? { capabilities: config.llm.capabilities }
+              : {}),
+          },
+        }
+      : {}),
+    ...(tool_layer.length ? { tool_layer } : {}),
+    ...(config.system_prompt_hash ||
+    config.prompt_version ||
+    config.template_ids?.length
+      ? {
+          prompt_layer: {
+            ...(config.system_prompt_hash
+              ? { system_prompt_hash: config.system_prompt_hash }
+              : {}),
+            ...(config.prompt_version
+              ? { prompt_version: config.prompt_version }
+              : {}),
+            ...(config.template_ids?.length
+              ? { template_ids: config.template_ids }
+              : {}),
+          },
+        }
+      : {}),
+    ...(config.granted_scopes?.length ||
+    config.data_access?.length ||
+    config.credential_references?.length
+      ? {
+          permission_layer: {
+            ...(config.granted_scopes?.length
+              ? { granted_scopes: config.granted_scopes }
+              : {}),
+            ...(config.data_access?.length
+              ? { data_access: config.data_access }
+              : {}),
+            ...(config.credential_references?.length
+              ? { credential_references: config.credential_references }
+              : {}),
+          },
+        }
+      : {}),
+    ...(config.workflows?.length
+      ? {
+          workflow_layer: config.workflows.map((wf) => ({
+            workflow_id: wf.workflow_id,
+            workflow_name: wf.workflow_name,
+            ...(wf.description ? { description: wf.description } : {}),
+            ...(wf.version ? { version: wf.version } : {}),
+            steps: wf.steps.map((s) => ({
+              step_id: s.step_id,
+              action: s.action,
+              ...(s.description ? { description: s.description } : {}),
+              ...(s.depends_on?.length ? { depends_on: s.depends_on } : {}),
+              ...(s.allowed_tools?.length
+                ? { allowed_tools: s.allowed_tools }
+                : {}),
+            })),
+          })),
+        }
+      : {}),
+    attestation: {
+      generator: attestation.generator,
+      generator_version: attestation.generator_version,
+    },
+  };
+
+  return bom;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/** Convert a human-readable name to a URL-friendly slug for use as `tool_id`. */
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/packages/agentbom-core/src/index.ts
+++ b/packages/agentbom-core/src/index.ts
@@ -1869,3 +1869,14 @@ export {
   checkCompliance,
   computeWeightedScore,
 } from "./compliance.js";
+
+// Shared manifest generator — exported from generate.ts
+export {
+  type AgentBOMGenerateInput,
+  type AgentBOMLLMInput,
+  type AgentBOMRecord,
+  type AgentBOMToolInput,
+  type AgentBOMWorkflowInput,
+  type AgentBOMWorkflowStepInput,
+  buildAgentBOM,
+} from "./generate.js";

--- a/packages/agentbom-langchain/src/index.ts
+++ b/packages/agentbom-langchain/src/index.ts
@@ -11,6 +11,10 @@
  * instance.
  */
 
+import { type AgentBOMRecord, buildAgentBOM } from "@wasmagent/agentbom-core";
+
+export type { AgentBOMRecord } from "@wasmagent/agentbom-core";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -58,49 +62,6 @@ export interface LangChainAgentConfig {
   credential_references?: string[];
 }
 
-/** The shape of a generated AgentBOM document.  Not a strict type — any
- *  valid AgentBOM v0.1 JSON object is acceptable; this type captures what
- *  this adapter populates. */
-export interface AgentBOMRecord {
-  agentbom_version: string;
-  identity: {
-    agent_id: string;
-    agent_name: string;
-    agent_version?: string;
-    deployment_context?: string;
-    generated_at: string;
-  };
-  model_layer?: {
-    provider: string;
-    model_id: string;
-    model_version?: string;
-    capabilities?: string[];
-  };
-  tool_layer?: Array<{
-    tool_id: string;
-    tool_name: string;
-    source: "mcp" | "builtin" | "plugin";
-    mcp_server_id?: string;
-    skills?: string[];
-    permissions?: string[];
-    risk_signals?: string[];
-  }>;
-  prompt_layer?: {
-    system_prompt_hash?: string;
-    prompt_version?: string;
-    template_ids?: string[];
-  };
-  permission_layer?: {
-    granted_scopes?: string[];
-    data_access?: string[];
-    credential_references?: string[];
-  };
-  attestation: {
-    generator: string;
-    generator_version: string;
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Generator
 // ---------------------------------------------------------------------------
@@ -116,95 +77,8 @@ const GENERATOR_VERSION = "0.0.0-research";
  * against `specs/agentbom/schema.json`.
  */
 export function generateAgentBOM(config: LangChainAgentConfig): AgentBOMRecord {
-  const now = new Date().toISOString();
-
-  const tool_layer = (config.tools ?? []).map((t) => ({
-    tool_id: t.id ?? slugify(t.name),
-    tool_name: t.description ?? t.name,
-    source: t.source ?? "builtin",
-    ...(t.mcp_server_id ? { mcp_server_id: t.mcp_server_id } : {}),
-    ...(t.skills?.length ? { skills: t.skills } : {}),
-    ...(t.permissions?.length ? { permissions: t.permissions } : {}),
-    ...(t.risk_signals?.length ? { risk_signals: t.risk_signals } : {}),
-  }));
-
-  const bom: AgentBOMRecord = {
-    agentbom_version: "0.1",
-    identity: {
-      agent_id: config.agent_id,
-      agent_name: config.agent_name,
-      ...(config.agent_version ? { agent_version: config.agent_version } : {}),
-      ...(config.deployment_context
-        ? { deployment_context: config.deployment_context }
-        : {}),
-      generated_at: now,
-    },
-    ...(config.llm
-      ? {
-          model_layer: {
-            provider: config.llm.provider,
-            model_id: config.llm.model_id,
-            ...(config.llm.model_version
-              ? { model_version: config.llm.model_version }
-              : {}),
-            ...(config.llm.capabilities?.length
-              ? { capabilities: config.llm.capabilities }
-              : {}),
-          },
-        }
-      : {}),
-    ...(tool_layer.length ? { tool_layer } : {}),
-    ...(config.system_prompt_hash ||
-    config.prompt_version ||
-    config.template_ids?.length
-      ? {
-          prompt_layer: {
-            ...(config.system_prompt_hash
-              ? { system_prompt_hash: config.system_prompt_hash }
-              : {}),
-            ...(config.prompt_version
-              ? { prompt_version: config.prompt_version }
-              : {}),
-            ...(config.template_ids?.length
-              ? { template_ids: config.template_ids }
-              : {}),
-          },
-        }
-      : {}),
-    ...(config.granted_scopes?.length ||
-    config.data_access?.length ||
-    config.credential_references?.length
-      ? {
-          permission_layer: {
-            ...(config.granted_scopes?.length
-              ? { granted_scopes: config.granted_scopes }
-              : {}),
-            ...(config.data_access?.length
-              ? { data_access: config.data_access }
-              : {}),
-            ...(config.credential_references?.length
-              ? { credential_references: config.credential_references }
-              : {}),
-          },
-        }
-      : {}),
-    attestation: {
-      generator: GENERATOR,
-      generator_version: GENERATOR_VERSION,
-    },
-  };
-
-  return bom;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Convert a human-readable name to a URL-friendly slug for use as `tool_id`. */
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+  return buildAgentBOM(config, {
+    generator: GENERATOR,
+    generator_version: GENERATOR_VERSION,
+  });
 }

--- a/packages/agentbom-llamaindex/src/index.ts
+++ b/packages/agentbom-llamaindex/src/index.ts
@@ -11,6 +11,10 @@
  * instance.
  */
 
+import { type AgentBOMRecord, buildAgentBOM } from "@wasmagent/agentbom-core";
+
+export type { AgentBOMRecord } from "@wasmagent/agentbom-core";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -58,47 +62,6 @@ export interface LlamaIndexAgentConfig {
   credential_references?: string[];
 }
 
-/** The shape of a generated AgentBOM document. */
-export interface AgentBOMRecord {
-  agentbom_version: string;
-  identity: {
-    agent_id: string;
-    agent_name: string;
-    agent_version?: string;
-    deployment_context?: string;
-    generated_at: string;
-  };
-  model_layer?: {
-    provider: string;
-    model_id: string;
-    model_version?: string;
-    capabilities?: string[];
-  };
-  tool_layer?: Array<{
-    tool_id: string;
-    tool_name: string;
-    source: "mcp" | "builtin" | "plugin";
-    mcp_server_id?: string;
-    skills?: string[];
-    permissions?: string[];
-    risk_signals?: string[];
-  }>;
-  prompt_layer?: {
-    system_prompt_hash?: string;
-    prompt_version?: string;
-    template_ids?: string[];
-  };
-  permission_layer?: {
-    granted_scopes?: string[];
-    data_access?: string[];
-    credential_references?: string[];
-  };
-  attestation: {
-    generator: string;
-    generator_version: string;
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Generator
 // ---------------------------------------------------------------------------
@@ -116,95 +79,8 @@ const GENERATOR_VERSION = "0.0.0-research";
 export function generateAgentBOM(
   config: LlamaIndexAgentConfig,
 ): AgentBOMRecord {
-  const now = new Date().toISOString();
-
-  const tool_layer = (config.tools ?? []).map((t) => ({
-    tool_id: t.id ?? slugify(t.name),
-    tool_name: t.description ?? t.name,
-    source: t.source ?? "builtin",
-    ...(t.mcp_server_id ? { mcp_server_id: t.mcp_server_id } : {}),
-    ...(t.skills?.length ? { skills: t.skills } : {}),
-    ...(t.permissions?.length ? { permissions: t.permissions } : {}),
-    ...(t.risk_signals?.length ? { risk_signals: t.risk_signals } : {}),
-  }));
-
-  const bom: AgentBOMRecord = {
-    agentbom_version: "0.1",
-    identity: {
-      agent_id: config.agent_id,
-      agent_name: config.agent_name,
-      ...(config.agent_version ? { agent_version: config.agent_version } : {}),
-      ...(config.deployment_context
-        ? { deployment_context: config.deployment_context }
-        : {}),
-      generated_at: now,
-    },
-    ...(config.llm
-      ? {
-          model_layer: {
-            provider: config.llm.provider,
-            model_id: config.llm.model_id,
-            ...(config.llm.model_version
-              ? { model_version: config.llm.model_version }
-              : {}),
-            ...(config.llm.capabilities?.length
-              ? { capabilities: config.llm.capabilities }
-              : {}),
-          },
-        }
-      : {}),
-    ...(tool_layer.length ? { tool_layer } : {}),
-    ...(config.system_prompt_hash ||
-    config.prompt_version ||
-    config.template_ids?.length
-      ? {
-          prompt_layer: {
-            ...(config.system_prompt_hash
-              ? { system_prompt_hash: config.system_prompt_hash }
-              : {}),
-            ...(config.prompt_version
-              ? { prompt_version: config.prompt_version }
-              : {}),
-            ...(config.template_ids?.length
-              ? { template_ids: config.template_ids }
-              : {}),
-          },
-        }
-      : {}),
-    ...(config.granted_scopes?.length ||
-    config.data_access?.length ||
-    config.credential_references?.length
-      ? {
-          permission_layer: {
-            ...(config.granted_scopes?.length
-              ? { granted_scopes: config.granted_scopes }
-              : {}),
-            ...(config.data_access?.length
-              ? { data_access: config.data_access }
-              : {}),
-            ...(config.credential_references?.length
-              ? { credential_references: config.credential_references }
-              : {}),
-          },
-        }
-      : {}),
-    attestation: {
-      generator: GENERATOR,
-      generator_version: GENERATOR_VERSION,
-    },
-  };
-
-  return bom;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Convert a human-readable name to a URL-friendly slug for use as `tool_id`. */
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+  return buildAgentBOM(config, {
+    generator: GENERATOR,
+    generator_version: GENERATOR_VERSION,
+  });
 }


### PR DESCRIPTION
## Summary

Cleans up the open patrol duplication findings and the cross-repo dependency request. Net −649 lines (+554/−1203).

Closes #43
Closes #50

### Deduplication (jscpd findings, #41/#42/#43)

- **Compliance engine** (largest hotspot, 342L): `agentbom-cli/compliance-check.ts` carried a full copy of the compliance checker. It now calls `checkCompliance` / `ComplianceProfile` from `@wasmagent/agentbom-core`; the local engine copy is deleted.
- **Adapter generators** (79L / 73L / 57L / 38L): the langchain, autogen, and llamaindex packages carried three near-identical `generateAgentBOM` implementations and `AgentBOMRecord` types. `agentbom-core` now provides a shared `buildAgentBOM` (`src/generate.ts`); adapters keep their framework-specific config types and delegate to it. Public APIs unchanged (types re-exported).
- **Profile compatibility input** (54L): `verifyProfileCommand` / `upgradeProfileCommand` shared a duplicated input-mapping block — extracted into `toCompatibilityProfileInput`.
- **JSON file reading** (25L / 40L / 27L): the private `readJsonFile` in `index.ts` was line-identical to the exported `readArtifactFile` in `trust-publish.ts`; index, both diff commands, and the mcp-posture inspect/validate commands now use the shared reader.
- **Migrate commands** (31L): `agentbomMigrateCommand` / `postureMigrateCommand` bodies were near-identical — extracted `runMigrateCommand`.

One behavioral note: file-read errors in `compliance-check` now use the shared reader's message (`cannot read file "..."` instead of `cannot read AgentBOM file "..."`); the corresponding test assertion was updated.

### `agentbom validate` command (#50)

`claude-bot-go` asked for a published, versioned AgentBOM schema with a CLI validator. The versioned schema (canonical SSOT in `@wasmagent/protocol`, supported versions + migrations in core) and validator API already existed; this adds the missing standalone CLI surface:

```
agent-trust agentbom validate <bom.json>   # exit 0 + "Valid AgentBOM v0.1", exit 1 with error details
```

with tests. The Go-side integration (native validator or shelling out to the CLI) belongs to `claude-bot-go`.

## Verification

- `biome check .` — clean
- `turbo run build` — 5/5 packages
- `turbo run test` — all suites pass (CLI 356 tests incl. 4 new validate tests; core 304; adapters unchanged)