### PR TITLE
fix: code review findings across CLI trust commands

### DIFF
--- a/packages/agentbom-cli/src/bom-generate.ts
+++ b/packages/agentbom-cli/src/bom-generate.ts
@@ -222,10 +222,19 @@ function generateRiskAssessment(toolLayer: ToolDefinition[]): Array<{
   }> = [];
 
   for (const tool of toolLayer) {
+    // risk_id must be unique per tool — downstream diffing keys risks by id
+    let seq = 0;
+    const pushRisk = (risk: Omit<(typeof risks)[number], "risk_id">): void => {
+      seq += 1;
+      risks.push({
+        risk_id: `risk-${tool.tool_id}-${String(seq).padStart(3, "0")}`,
+        ...risk,
+      });
+    };
+
     // Check for high-risk tools
     if (tool.tool_id === "bash-exec" || tool.tool_id.includes("exec")) {
-      risks.push({
-        risk_id: `risk-${tool.tool_id}-001`,
+      pushRisk({
         severity: "medium",
         category: "command_execution",
         description: `${tool.tool_name} tool allows arbitrary process execution`,
@@ -238,8 +247,7 @@ function generateRiskAssessment(toolLayer: ToolDefinition[]): Array<{
       tool.source === "mcp" &&
       tool.permissions.some((p) => p.includes("network"))
     ) {
-      risks.push({
-        risk_id: `risk-${tool.tool_id}-001`,
+      pushRisk({
         severity: "high",
         category: "ssrf",
         description: `${tool.tool_name} makes outbound network requests`,
@@ -249,8 +257,7 @@ function generateRiskAssessment(toolLayer: ToolDefinition[]): Array<{
 
     // Check for file write operations
     if (tool.permissions.includes("fs:write")) {
-      risks.push({
-        risk_id: `risk-${tool.tool_id}-002`,
+      pushRisk({
         severity: "low",
         category: "data_modification",
         description: `${tool.tool_name} can modify files in the workspace`,
@@ -356,7 +363,14 @@ export function generateAgentBOMCommand(args: string[]): number {
   // Output the AgentBOM JSON
   const output = `${JSON.stringify(agentbom, null, 2)}\n`;
   if (parsed.outputPath) {
-    writeFileSync(resolve(parsed.outputPath), output, "utf-8");
+    try {
+      writeFileSync(resolve(parsed.outputPath), output, "utf-8");
+    } catch (err) {
+      console.error(
+        `Error: cannot write AgentBOM to "${parsed.outputPath}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 1;
+    }
   } else {
     console.log(output.trimEnd());
   }

--- a/packages/agentbom-cli/src/chain.ts
+++ b/packages/agentbom-cli/src/chain.ts
@@ -70,7 +70,7 @@ export interface ChainReport {
   steps: ChainStepResult[];
 }
 
-/** Ordered step identifiers — the 6 chain nodes joined by 5 verifiable links. */
+/** Ordered step identifiers for the chain (bscode workload → … → Trust Passport). */
 export const CHAIN_STEPS = [
   "manifest",
   "agentbom",
@@ -462,7 +462,14 @@ export function chainCommand(args: string[]): number {
   }
 
   const resolvedOut = resolve(outPath);
-  writeFileSync(resolvedOut, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+  try {
+    writeFileSync(resolvedOut, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+  } catch (err) {
+    console.error(
+      `Error: cannot write chain report to "${resolvedOut}": ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 1;
+  }
 
   if (report.overall.status !== "valid") {
     const failed = report.steps

--- a/packages/agentbom-cli/src/compliance-check.ts
+++ b/packages/agentbom-cli/src/compliance-check.ts
@@ -12,7 +12,7 @@ import {
 } from "@wasmagent/agentbom-core";
 import { readArtifactFile } from "./trust-publish.js";
 
-function loadProfile(profileId: string): ComplianceProfile | null {
+export function loadProfile(profileId: string): ComplianceProfile | null {
   const profilesDir = resolve(
     dirname(fileURLToPath(import.meta.url)),
     "../profiles",

--- a/packages/agentbom-cli/src/passport-sign.ts
+++ b/packages/agentbom-cli/src/passport-sign.ts
@@ -32,12 +32,17 @@ export function readKeySeed(keyPath: string): Uint8Array {
     // PKCS#8 Ed25519 DER: 30 2e 02 01 00 30 05 06 03 2b 65 70 04 22 04 20 <32-byte seed>
     const b64 = raw.replace(/-----[^-]+-----/g, "").replace(/\s+/g, "");
     const der = Buffer.from(b64, "base64");
-    // Seed starts at offset 16 in standard PKCS#8 Ed25519 DER
-    if (der.length >= 48) {
-      return new Uint8Array(der.slice(16, 48));
+    const pkcs8Ed25519Prefix = Buffer.from(
+      "302e020100300506032b657004220420",
+      "hex",
+    );
+    // Validate the DER prefix so a non-Ed25519 PKCS#8 key fails loudly instead
+    // of silently signing with arbitrary bytes.
+    if (der.length >= 48 && der.subarray(0, 16).equals(pkcs8Ed25519Prefix)) {
+      return new Uint8Array(der.subarray(16, 48));
     }
     throw new Error(
-      `Cannot extract seed from PEM in "${keyPath}" — unexpected DER length ${der.length}`,
+      `Cannot extract seed from PEM in "${keyPath}" — expected a PKCS#8 Ed25519 private key (-----BEGIN PRIVATE KEY-----)`,
     );
   }
 

--- a/packages/agentbom-cli/src/regulatory-report.ts
+++ b/packages/agentbom-cli/src/regulatory-report.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env bun
 import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { validateAgentBOM } from "@wasmagent/agentbom-core";
+import { resolve } from "node:path";
+import {
+  type ComplianceProfile,
+  validateAgentBOM,
+} from "@wasmagent/agentbom-core";
+import { loadProfile } from "./compliance-check.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,44 +35,6 @@ type EvidenceLevel = "summary" | "detailed";
 
 /** Output format */
 type ReportFormat = "text" | "json";
-
-interface ComplianceProfile {
-  profile_version: string;
-  profile_id: string;
-  framework: {
-    name: string;
-    version: string;
-    description?: string;
-  };
-  rules: {
-    identity?: {
-      required_fields?: string[];
-      allowed_contexts?: string[];
-      requires_version?: boolean;
-    };
-    tool_layer?: {
-      max_severity?: string;
-      requires_tool_inventory?: boolean;
-      blocked_permissions?: string[];
-      blocked_sources?: string[];
-    };
-    risk_layer?: {
-      requires_risk_assessment?: boolean;
-      max_unmitigated_critical?: number;
-      max_unmitigated_high?: number;
-      max_unmitigated_medium?: number;
-      requires_mitigation_for?: string[];
-    };
-    attestation?: {
-      requires_signature?: boolean;
-      requires_timestamp?: boolean;
-    };
-  };
-  metadata?: {
-    author?: string;
-    documentation_url?: string;
-  };
-}
 
 /** A single control objective in the report */
 interface ControlObjective {
@@ -882,24 +847,6 @@ function assessAIActOversight(
 }
 
 // ---------------------------------------------------------------------------
-// Profile loading
-// ---------------------------------------------------------------------------
-
-function loadProfile(profileId: string): ComplianceProfile | null {
-  const profilesDir = resolve(
-    dirname(fileURLToPath(import.meta.url)),
-    "../profiles",
-  );
-  const profilePath = resolve(profilesDir, `${profileId}.json`);
-  try {
-    const raw = readFileSync(profilePath, "utf-8");
-    return JSON.parse(raw) as ComplianceProfile;
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Report generation
 // ---------------------------------------------------------------------------
 
@@ -1196,18 +1143,14 @@ export function reportCommand(args: string[]): number {
     return 1;
   }
 
-  // Load compliance profile
-  const profileId = FRAMEWORK_TO_PROFILE[framework];
-
   // Load compliance profile from file
-  let profile: ComplianceProfile;
-  const loaded = loadProfile(profileId);
-  if (!loaded) {
+  const profileId = FRAMEWORK_TO_PROFILE[framework];
+  const profile = loadProfile(profileId);
+  if (!profile) {
     console.error(`Error: cannot load compliance profile "${profileId}"`);
     console.error(`Expected file: profiles/${profileId}.json`);
     return 1;
   }
-  profile = loaded;
 
   // Build report
   const report = buildReport(

--- a/packages/agentbom-cli/src/sigstore-verify.ts
+++ b/packages/agentbom-cli/src/sigstore-verify.ts
@@ -9,7 +9,7 @@
  *
  * Uses node:crypto for all cryptographic operations (no external deps).
  */
-import { createHash, createVerify, X509Certificate } from "node:crypto";
+import { createHash, createVerify, verify, X509Certificate } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { validateTrustPassport } from "@openagentaudit/passport";
@@ -148,9 +148,9 @@ function verifyArtifactSignature(
   try {
     const keyType = cert.publicKey.asymmetricKeyType;
     if (keyType === "ed25519") {
-      const v = createVerify("Ed25519");
-      v.update(artifact);
-      return v.verify(cert.publicKey, signature);
+      // Ed25519 is a one-shot algorithm: createVerify/createSign reject it as a
+      // digest name ("Invalid digest"), so use the one-pass crypto.verify form.
+      return verify(null, artifact, cert.publicKey, signature);
     }
     // RSA / ECDSA — try SHA-256, then SHA-384, then SHA-512
     for (const hash of ["sha256", "sha384", "sha512"] as const) {
@@ -485,7 +485,11 @@ export function verifySigstoreCommand(args: string[]): number {
       JSON.stringify(
         {
           valid: result.valid,
-          signature: result.signatureValid ? "valid" : "invalid",
+          signature: result.signatureValid
+            ? "valid"
+            : artifactPath
+              ? "invalid"
+              : "not_checked",
           certificate: result.certificateValid ? "valid" : "invalid",
           tlog: result.tlogVerified ? "verified" : "not_verified",
           artifact: result.artifactValid ? "valid" : "not_checked",

--- a/packages/agentbom-cli/src/trust-publish.test.ts
+++ b/packages/agentbom-cli/src/trust-publish.test.ts
@@ -291,7 +291,7 @@ describe("parsePublishArgs", () => {
     const artifactPath = writeJson("bom.json", VALID_AGENTBOM);
     const result = parsePublishArgs([artifactPath, "--registry"]);
     expect(typeof result).toBe("string");
-    expect(result).toContain("unknown argument");
+    expect(result).toContain("--registry requires");
   });
 
   it("resolves artifact path to absolute", () => {

--- a/packages/agentbom-cli/src/trust-publish.ts
+++ b/packages/agentbom-cli/src/trust-publish.ts
@@ -300,10 +300,12 @@ export function parsePublishArgs(args: string[]): PublishConfig | string {
     const arg = args[i];
     const next = args[i + 1];
 
-    if (arg === "--registry" && next) {
+    if (arg === "--registry") {
+      if (!next) return `Error: --registry requires a directory value`;
       registryDir = next;
       i++;
-    } else if (arg === "--tag" && next) {
+    } else if (arg === "--tag") {
+      if (!next) return `Error: --tag requires a tag value`;
       tag = next;
       i++;
     } else {

--- a/packages/agentbom-cli/src/trust-pull.ts
+++ b/packages/agentbom-cli/src/trust-pull.ts
@@ -217,8 +217,22 @@ export function extractDependencyIds(data: Record<string, unknown>): string[] {
 }
 
 /**
+ * Shared resolution state for dependency traversal.
+ *
+ * `memo` deduplicates diamond dependencies (the same CAS id reached via
+ * multiple paths resolves once and its result is reused). `inProgress` holds
+ * CAS ids on the current DFS path, so genuine cycles (A → B → A) are reported
+ * instead of looping.
+ */
+interface DependencyResolutionState {
+  memo: Map<string, ResolvedDependency>;
+  inProgress: Set<string>;
+}
+
+/**
  * Resolve a single declared dependency, optionally recursing into its own
- * dependencies. Cycle-safe via the `visited` set of already-resolved CAS ids.
+ * dependencies. Cycle-safe via the in-progress set. Diamond dependencies are
+ * deduplicated via the memo, not misreported as cycles.
  *
  * Pure with respect to the filesystem: reads only. Never throws — unresolved or
  * corrupt dependencies are reported via the `error`/`resolved` fields.
@@ -226,7 +240,7 @@ export function extractDependencyIds(data: Record<string, unknown>): string[] {
 function resolveSingleDependency(
   depId: string,
   registryDir: string,
-  visited: Set<string>,
+  state: DependencyResolutionState,
   recurse: boolean,
 ): ResolvedDependency {
   const base: ResolvedDependency = { artifactId: depId, resolved: false };
@@ -240,18 +254,23 @@ function resolveSingleDependency(
   }
 
   const casId = resolved.casId;
-  if (visited.has(casId)) {
+  if (state.inProgress.has(casId)) {
     return {
       ...base,
       resolved: true,
       casId,
-      error: "cycle — already resolved",
+      error: "cycle — already being resolved",
     };
   }
-  visited.add(casId);
+  const memoized = state.memo.get(casId);
+  if (memoized) {
+    return memoized;
+  }
+  state.inProgress.add(casId);
 
   const objectPath = objectPathForCasId(casId, registryDir);
   if (!existsSync(objectPath)) {
+    state.inProgress.delete(casId);
     return {
       ...base,
       resolved: false,
@@ -264,6 +283,7 @@ function resolveSingleDependency(
   try {
     raw = readFileSync(objectPath, "utf-8");
   } catch {
+    state.inProgress.delete(casId);
     return {
       ...base,
       resolved: false,
@@ -277,6 +297,7 @@ function resolveSingleDependency(
   try {
     const data = JSON.parse(raw);
     if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      state.inProgress.delete(casId);
       return {
         ...base,
         resolved: true,
@@ -287,6 +308,7 @@ function resolveSingleDependency(
     }
     parsed = data as Record<string, unknown>;
   } catch {
+    state.inProgress.delete(casId);
     return {
       ...base,
       resolved: true,
@@ -309,10 +331,12 @@ function resolveSingleDependency(
   if (recurse) {
     const childIds = extractDependencyIds(parsed);
     result.dependencies = childIds.map((id) =>
-      resolveSingleDependency(id, registryDir, visited, recurse),
+      resolveSingleDependency(id, registryDir, state, recurse),
     );
   }
 
+  state.inProgress.delete(casId);
+  state.memo.set(casId, result);
   return result;
 }
 
@@ -320,7 +344,8 @@ function resolveSingleDependency(
  * Resolve all declared dependencies of an artifact.
  *
  * When `recurse` is true, each dependency's own dependencies are resolved
- * transitively (cycle-safe). Returns one {@link ResolvedDependency} per
+ * transitively (cycle-safe). Diamond (shared) dependencies resolve once and
+ * reuse the first result. Returns one {@link ResolvedDependency} per
  * declared id, in declaration order.
  */
 export function resolveDependencies(
@@ -328,9 +353,12 @@ export function resolveDependencies(
   registryDir: string,
   recurse: boolean,
 ): ResolvedDependency[] {
-  const visited = new Set<string>();
+  const state: DependencyResolutionState = {
+    memo: new Map(),
+    inProgress: new Set(),
+  };
   return dependencyIds.map((id) =>
-    resolveSingleDependency(id, registryDir, visited, recurse),
+    resolveSingleDependency(id, registryDir, state, recurse),
   );
 }
 

--- a/packages/agentbom-cli/src/trust-subscribe.ts
+++ b/packages/agentbom-cli/src/trust-subscribe.ts
@@ -472,13 +472,22 @@ export async function subscribeCommand(args: string[]): Promise<number> {
         });
       }
 
-      // Update baseline to latest artifact to avoid re-alerting on same drift
-      if (result.scannedFiles.length > 0) {
-        const latestFile = result.scannedFiles[result.scannedFiles.length - 1];
-        const latestData = readJsonRecord(latestFile);
-        if (latestData) {
-          config.baselinePath = latestFile;
+      // Update baseline to the newest scanned artifact (by generated_at) to
+      // avoid re-alerting on the same drift
+      let latestFile: string | undefined;
+      let latestTs = Number.NEGATIVE_INFINITY;
+      for (const file of result.scannedFiles) {
+        if (resolve(file) === resolve(config.baselinePath)) continue;
+        const data = readJsonRecord(file);
+        if (!data) continue;
+        const ts = Date.parse(extractTimestamp(data));
+        if (!Number.isNaN(ts) && ts > latestTs) {
+          latestTs = ts;
+          latestFile = file;
         }
+      }
+      if (latestFile) {
+        config.baselinePath = latestFile;
       }
     } else {
       console.log(

--- a/packages/agentbom-cli/src/trust-verify-chain.ts
+++ b/packages/agentbom-cli/src/trust-verify-chain.ts
@@ -266,6 +266,15 @@ function validateArtifactNode(data: unknown): {
   };
 }
 
+/** Cached per-CAS validation outcome, including integrity status. */
+interface CachedValidation {
+  valid: boolean;
+  nodeType: ChainNodeResult["nodeType"];
+  errors: string[];
+  artifactType: ArtifactType;
+  integrityVerified: boolean;
+}
+
 /**
  * Verify a single artifact node and recursively verify its references.
  *
@@ -287,15 +296,7 @@ function verifyNode(
   currentDepth: number,
   remainingDepth: number,
   visited: Set<string>,
-  cache: Map<
-    string,
-    {
-      valid: boolean;
-      nodeType: ChainNodeResult["nodeType"];
-      errors: string[];
-      artifactType: ArtifactType;
-    }
-  >,
+  cache: Map<string, CachedValidation>,
   allNodes: ChainNodeResult[],
   stats: { cacheHits: number; cacheMisses: number },
 ): ChainNodeResult {
@@ -336,7 +337,7 @@ function verifyNode(
     node.nodeType = cached.nodeType;
     node.valid = cached.valid;
     node.artifactType = cached.artifactType;
-    node.integrityVerified = true;
+    node.integrityVerified = cached.integrityVerified;
     stats.cacheHits++;
     allNodes.push(node);
     return node;
@@ -352,6 +353,7 @@ function verifyNode(
       nodeType: "unknown",
       errors: node.errors,
       artifactType: "unknown",
+      integrityVerified: false,
     });
     allNodes.push(node);
     return node;
@@ -380,13 +382,19 @@ function verifyNode(
     node.errors.length === 0;
 
   // Cache the result
-  cache.set(casId, validation);
+  cache.set(casId, {
+    ...validation,
+    integrityVerified: node.integrityVerified ?? false,
+  });
 
   // Recurse into references (if depth allows)
   if (remainingDepth > 0) {
-    const refs = validation.valid
-      ? extractArtifactReferences(pullResult.artifact)
-      : extractPassportReferences(pullResult.artifact);
+    // Passports reference artifacts via agentbom_ref/posture_ref/dependencies;
+    // other artifacts via distribution.supersedes/dependencies.
+    const refs =
+      validation.nodeType === "passport"
+        ? extractPassportReferences(pullResult.artifact)
+        : extractArtifactReferences(pullResult.artifact);
 
     for (const ref of refs) {
       const child = verifyNode(
@@ -460,15 +468,7 @@ export function verifyChain(
   let maxDepthReached = 0;
 
   if (config.maxDepth > 0) {
-    const cache = new Map<
-      string,
-      {
-        valid: boolean;
-        nodeType: ChainNodeResult["nodeType"];
-        errors: string[];
-        artifactType: ArtifactType;
-      }
-    >();
+    const cache = new Map<string, CachedValidation>();
     const visited = new Set<string>();
     const stats = { cacheHits: 0, cacheMisses: 0 };
 


### PR DESCRIPTION
## Summary

Full code review of core + CLI (all packages, ~7k lines) produced 10 fixes: 2 high-severity correctness bugs, 5 medium, 3 low/hardening. Net +138/−126.

### High severity

1. **`sigstore-verify`: Ed25519 signatures could never verify.** `createVerify("Ed25519")` throws `Invalid digest` in both Node and Bun (reproduced on v24 / 1.3); the surrounding catch swallowed it and returned `false`, so every Ed25519-signed bundle failed verification. Now uses the one-shot `crypto.verify(null, …)` form. Verified end-to-end with a real Ed25519 cert: a valid bundle/artifact now passes (`valid: true`), a tampered artifact is still rejected.
2. **`trust-verify-chain`: nested passport references were never followed.** The reference extractor was selected by `validation.valid` instead of node type, so a *valid* nested Trust Passport went through `extractArtifactReferences` (which only reads `distribution.supersedes`/`dependencies`) and its `agentbom_ref`/`posture_ref` were silently skipped. Selection is now by `nodeType === "passport"`.
3. **`trust-verify-chain`: cache hits reported `integrityVerified: true` unconditionally**, even for artifacts whose pull or integrity check had failed. The cache entry now carries integrity status.

### Medium severity

4. **`bom-generate`: duplicate `risk_id`s.** A tool triggering multiple risk categories (e.g. exec + network) emitted two `risk-<tool>-001` entries; downstream diffing keys risks by id and silently dropped one. Ids are now numbered per tool.
5. **`trust-subscribe`: baseline rotation picked the wrong file.** Continuous mode rotated the baseline to the alphabetically-last scanned file (readdir order), which could re-alert and re-POST the callback every cycle forever. Now picks the newest artifact by `identity.generated_at`.
6. **`trust-pull`: diamond dependencies mislabeled as cycles.** A shared dependency reached via two paths reported `error: "cycle — already resolved"`. Genuine cycles now use an in-progress DFS set; shared dependencies dedupe through a memo and reuse the first result.
7. **`sigstore-verify`: self-contradictory output.** Without `--artifact` the command printed `signature: "invalid"` next to `valid: true` / exit 0; it now prints `signature: "not_checked"`, matching the tlog/artifact/issuer labels.

### Low severity / hardening

8. `passport-sign`: the PKCS#8 Ed25519 DER prefix is validated before slicing the seed, so a non-Ed25519 PEM fails with a clear error instead of signing with arbitrary bytes.
9. `bom-generate` / `chain`: output `writeFileSync` calls are guarded — a bad `--out`/`--output` path now prints an error and exits 1 instead of a stack trace.
10. `trust-publish`: `--registry`/`--tag` without a value report a missing-value error instead of the misleading "unknown argument" (test updated). `regulatory-report` now reuses `ComplianceProfile` from core and the shared `loadProfile` instead of local copies. `chain`: stale "6 chain nodes" comment fixed (5 steps).

### Intentionally not changed

- `pipeline.ts` docstrings claim streaming/backpressure but `process()` buffers the whole source in stage 1 before processing. The claim/behavior gap is real; fixing it means rewriting the pipeline's architecture, which is out of scope for a review pass. Tracked here for a future issue.

## Verification

- `tsc --noEmit` (all 5 packages) ✓
- `biome check .` ✓
- `turbo run build` 5/5 ✓
- `turbo run test` — all suites, 0 failures ✓ (two assertions updated to the improved messages)
- End-to-end Ed25519 sigstore check with openssl-generated cert: valid → `valid: true`, tampered → rejected ✓